### PR TITLE
add labels with on-off and sprite attribute tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5649,6 +5649,12 @@
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
         },
+        "cssfontparser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+            "integrity": "sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=",
+            "dev": true
+        },
         "cssnano": {
             "version": "4.1.11",
             "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.11.tgz",
@@ -9557,6 +9563,16 @@
                 }
             }
         },
+        "jest-canvas-mock": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.3.1.tgz",
+            "integrity": "sha512-5FnSZPrX3Q2ZfsbYNE3wqKR3+XorN8qFzDzB5o0golWgt6EOX1+emBnpOc9IAQ+NXFj8Nzm3h7ZdE/9H0ylBcg==",
+            "dev": true,
+            "requires": {
+                "cssfontparser": "^1.2.1",
+                "moo-color": "^1.0.2"
+            }
+        },
         "jest-changed-files": {
             "version": "27.4.2",
             "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.4.2.tgz",
@@ -12463,6 +12479,23 @@
             "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
             "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
             "dev": true
+        },
+        "moo-color": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+            "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+            "dev": true,
+            "requires": {
+                "color-name": "^1.1.4"
+            },
+            "dependencies": {
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                }
+            }
         },
         "move-concurrently": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
         "gl": "4.9.2",
         "husky": "7.0.4",
         "jest": "27.4.7",
+        "jest-canvas-mock": "^2.3.1",
         "jest-matcher-deep-close-to": "1.3.0",
         "lint-staged": "12.1.2",
         "looks-same": "7.3.0",

--- a/src/components/ThreeDEditor.jsx
+++ b/src/components/ThreeDEditor.jsx
@@ -16,6 +16,7 @@ import {
     Replay,
     SwitchCamera,
     ThreeDRotation,
+    Spellcheck,
 } from "@material-ui/icons";
 import setClass from "classnames";
 import $ from "jquery";
@@ -76,6 +77,7 @@ export class ThreeDEditor extends React.Component {
         this.handleToggleBonds = this.handleToggleBonds.bind(this);
         this.toggleThreejsEditorModal = this.toggleThreejsEditorModal.bind(this);
         this.handleToggleOrthographicCamera = this.handleToggleOrthographicCamera.bind(this);
+        this.handleToggleLabels = this.handleToggleLabels.bind(this);
         this.handleToggleConventionalCell = this.handleToggleConventionalCell.bind(this);
         this.handleResetViewer = this.handleResetViewer.bind(this);
         this.handleTakeScreenshot = this.handleTakeScreenshot.bind(this);
@@ -130,6 +132,10 @@ export class ThreeDEditor extends React.Component {
     handleToggleOrthographicCamera() {
         this.WaveComponent.wave.toggleOrthographicCamera();
         this._resetStateWaveComponent();
+    }
+
+    handleToggleLabels() {
+        this.WaveComponent.wave.toggleLabels();
     }
 
     handleChemicalConnectivityFactorChange(e) {
@@ -350,6 +356,16 @@ export class ThreeDEditor extends React.Component {
                 onClick={this.handleToggleConventionalCell}
             >
                 <FormatShapes />
+            </RoundIconButton>,
+
+            <RoundIconButton
+                key="Toggle Labels"
+                tooltipPlacement="top"
+                title="Toggle Labels"
+                isToggled={this._getWaveProperty("areLabelsShown")}
+                onClick={this.handleToggleLabels}
+            >
+                <Spellcheck />
             </RoundIconButton>,
 
             <RoundIconButton

--- a/src/enums.js
+++ b/src/enums.js
@@ -153,3 +153,5 @@ export const BOUNDARY_CONDITIONS = [
         isNonPeriodic: true,
     },
 ];
+
+export const ATOM_GROUP_NAME = "Atoms";

--- a/src/mixins/atoms.js
+++ b/src/mixins/atoms.js
@@ -1,5 +1,7 @@
 import * as THREE from "three";
 
+import { ATOM_GROUP_NAME } from "../enums";
+
 /*
  * Mixin containing the logic for dealing with atoms.
  * Draws atoms as spheres and handles actions performed on them.
@@ -85,7 +87,7 @@ export const AtomsMixin = (superclass) =>
 
         createAtomsGroup(basis, atomRadiiScale) {
             const atomsGroup = new THREE.Group();
-            atomsGroup.name = "Atoms";
+            atomsGroup.name = ATOM_GROUP_NAME;
             basis.coordinates.forEach((atomicCoordinate, atomicIndex) => {
                 const element = basis.getElementByIndex(atomicIndex);
                 const sphereMesh = this.getSphereMeshObject({
@@ -94,6 +96,11 @@ export const AtomsMixin = (superclass) =>
                 });
                 sphereMesh.name = `${element}-${atomicIndex}`;
                 atomsGroup.add(sphereMesh);
+
+                const text = sphereMesh.name.split("-")[0];
+                const label = this.createLabel(text, `label-for-${sphereMesh.uuid}`);
+                label.position.set(...atomicCoordinate.value);
+                atomsGroup.add(label);
             });
             return atomsGroup;
         }

--- a/src/mixins/atoms.js
+++ b/src/mixins/atoms.js
@@ -98,7 +98,7 @@ export const AtomsMixin = (superclass) =>
                 atomsGroup.add(sphereMesh);
 
                 const text = sphereMesh.name.split("-")[0];
-                const label = this.createLabel(text, `label-for-${sphereMesh.uuid}`);
+                const label = this.createLabelSprite(text, `label-for-${sphereMesh.uuid}`);
                 label.position.set(...atomicCoordinate.value);
                 atomsGroup.add(label);
             });

--- a/src/mixins/labels.js
+++ b/src/mixins/labels.js
@@ -1,6 +1,8 @@
 import * as THREE from "three";
 
 import { ATOM_GROUP_NAME } from "../enums";
+// eslint-disable-next-line import/no-cycle
+import { setParameters } from "../utils";
 
 /*
  * Mixin containing the logic for dealing with atom labes.
@@ -8,43 +10,60 @@ import { ATOM_GROUP_NAME } from "../enums";
  */
 export const LabelsMixin = (superclass) =>
     class extends superclass {
+        #texturesCache = {};
+
+        /**
+         * Creates a new texture based on a 2D canvas with the supplied text
+         * @param {String} text - the text to be placed on the texture;
+         * @return {THREE.Texture}
+         */
         // eslint-disable-next-line class-methods-use-this
-        createTextTexture(text) {
-            const {
-                fontFace,
-                fontSize,
-                fontWeight,
-                fillColor,
-                strokeColor,
-                strokeLineWidth,
-                textAlign,
-                textBaseline,
-            } = this.settings.labels;
+        createLabelTextTexture(text) {
+            const { fontFace, fontSize, fontWeight, ...textParams } = this.settings.labelsConfig;
             const canvas = document.createElement("canvas");
             const context = canvas.getContext("2d");
+
             context.font = `${fontWeight} ${fontSize}px ${fontFace}`;
-            const metrics = context.measureText(text);
-            const textWidth = metrics.width;
+            const textWidth = context.measureText(text).width;
             const basicTextSize = textWidth > fontSize ? textWidth : fontSize;
             const textSizePowOf2 = 2 ** Math.floor(Math.log2(basicTextSize));
             const scaledFontSize = (fontSize * textSizePowOf2) / basicTextSize;
-            canvas.width = textSizePowOf2;
-            canvas.height = textSizePowOf2;
-            context.font = `${fontWeight} ${scaledFontSize}px ${fontFace}`;
-            context.textAlign = textAlign;
-            context.textBaseline = textBaseline;
-            context.fillStyle = fillColor;
-            context.strokeStyle = strokeColor;
-            context.lineWidth = strokeLineWidth;
+            setParameters(canvas, { width: textSizePowOf2, height: textSizePowOf2 });
+            const scaledFont = `${fontWeight} ${scaledFontSize}px ${fontFace}`;
+            setParameters(context, { font: scaledFont, ...textParams });
+
             context.fillText(text, context.canvas.width / 2, (context.canvas.height / 2) * 1.15);
             context.strokeText(text, context.canvas.width / 2, (context.canvas.height / 2) * 1.15);
+
             const texture = new THREE.Texture(canvas);
             texture.needsUpdate = true;
+
             return texture;
         }
 
-        createSprite(text, name) {
-            const texture = this.createTextTexture(text);
+        /**
+         * Returns cached or newly created texture with label text
+         * @param {String} text - the text to be placed on the texture;
+         * @return {THREE.Texture}
+         */
+        getLabelTextTexture(text) {
+            if (this.#texturesCache[text]) return this.#texturesCache[text];
+
+            const texture = this.createLabelTextTexture(text);
+            this.#texturesCache[text] = texture;
+            return texture;
+        }
+
+        /**
+         * Creates a sprite with a label text
+         * @param {String} text - the text displayed on the atom label;
+         * should be 1-2 symbols long to fit the square form of the label shown in front of a sphere
+         * @param {String} name - the name of the created sprite;
+         * naming convention: label-for-<atom mesh uuid>
+         * @return {THREE.Sprite}
+         */
+        createLabelSprite(text, name) {
+            const texture = this.getLabelTextTexture(text);
             const spriteMaterial = new THREE.SpriteMaterial({ map: texture });
             const sprite = new THREE.Sprite(spriteMaterial);
             sprite.name = name;
@@ -53,52 +72,62 @@ export const LabelsMixin = (superclass) =>
             return sprite;
         }
 
+        /**
+         * Adjusts the label sprite position so that its center is always
+         * in the point where the atom's bound sphere is intersected
+         * by the line joining the atom's center with the camera.
+         */
         adjustLabelsToCameraPosition() {
-            const { scene, camera } = this;
-            const cellCenter = this.getCellCenter();
-            const atomGroups =
-                scene
-                    .getObjectByName(ATOM_GROUP_NAME)
-                    ?.parent.children.filter((object) => object.name.includes(ATOM_GROUP_NAME)) ||
-                [];
+            if (!this.areLabelsShown) return;
+
+            const atomGroups = this.scene
+                .getObjectByName(ATOM_GROUP_NAME)
+                .parent.children.filter((object) => object.name.includes(ATOM_GROUP_NAME));
             atomGroups.forEach((group) => {
                 const labels = group.children.filter((child) => child instanceof THREE.Sprite);
                 labels.forEach((label) => {
                     const atomUUID = label.name.replace(/label-for-/, "");
-                    const atom = scene.getObjectByProperty("uuid", atomUUID);
-                    const atomRadius = atom.geometry.parameters.radius;
-
-                    const atomPosition = atom.position.clone().add(group.position);
-                    const vectorToCamera = this.isCameraOrthographic
-                        ? new THREE.Vector3(
-                              camera.position.x - cellCenter[0],
-                              camera.position.y - cellCenter[1],
-                              camera.position.z - cellCenter[2],
-                          )
-                        : new THREE.Vector3(
-                              camera.position.x - atomPosition.x,
-                              camera.position.y - atomPosition.y,
-                              camera.position.z - atomPosition.z,
-                          );
-
-                    const clampedVectorToCamera = vectorToCamera
-                        .clone()
-                        .clampLength(atomRadius, atomRadius);
+                    const atom = this.scene.getObjectByProperty("uuid", atomUUID);
+                    const clampedVectorToCamera = this.getClampedVectorToCamera(group, atom);
                     const newLabelPosition = atom.position.clone().add(clampedVectorToCamera);
                     label.position.copy(newLabelPosition);
                 });
             });
         }
 
+        /**
+         * Calculates a vector from atom to camera clamped to atom sphere radius
+         * @param {THREE.Group} group - the instance of THREE group containing the atom mesh
+         * @param {THREE.Mesh} atom - the instance of THREE mesh representing the atom
+         */
+        getClampedVectorToCamera(group, atom) {
+            const cellCenter = this.getCellCenter();
+            const atomRadius = atom.geometry.parameters.radius;
+            const atomPosition = atom.position.clone().add(group.position);
+            const vectorToCamera = this.isCameraOrthographic
+                ? new THREE.Vector3(
+                      this.camera.position.x - cellCenter[0],
+                      this.camera.position.y - cellCenter[1],
+                      this.camera.position.z - cellCenter[2],
+                  )
+                : new THREE.Vector3(
+                      this.camera.position.x - atomPosition.x,
+                      this.camera.position.y - atomPosition.y,
+                      this.camera.position.z - atomPosition.z,
+                  );
+            const clampedVectorToCamera = vectorToCamera.clampLength(atomRadius, atomRadius);
+            return clampedVectorToCamera;
+        }
+
+        /**
+         * Toggles the visibility of all the text labels within the atom group
+         */
         toggleLabels() {
             this.areLabelsShown = !this.areLabelsShown;
 
-            const { scene } = this;
-            const atomGroups =
-                scene
-                    .getObjectByName(ATOM_GROUP_NAME)
-                    ?.parent.children.filter((object) => object.name.includes(ATOM_GROUP_NAME)) ||
-                [];
+            const atomGroups = this.scene
+                .getObjectByName(ATOM_GROUP_NAME)
+                .parent.children.filter((object) => object.name.includes(ATOM_GROUP_NAME));
             const labels = atomGroups
                 .map((group) => group.children.filter((child) => child instanceof THREE.Sprite))
                 .flat();
@@ -107,9 +136,5 @@ export const LabelsMixin = (superclass) =>
             });
 
             this.render();
-        }
-
-        createLabel(message, name) {
-            return this.createSprite(message, name);
         }
     };

--- a/src/mixins/labels.js
+++ b/src/mixins/labels.js
@@ -73,8 +73,8 @@ export const LabelsMixin = (superclass) =>
         }
 
         /**
-         * Adjusts the label sprite position so that its center is always
-         * in the point where the atom's bound sphere is intersected
+         * Adjusts the label sprites' positions so that the center of every sprite
+         * is always in the point where the atom's bound sphere is intersected
          * by the line joining the atom's center with the camera.
          */
         adjustLabelsToCameraPosition() {
@@ -96,9 +96,9 @@ export const LabelsMixin = (superclass) =>
         }
 
         /**
-         * Calculates a vector from atom to camera clamped to atom sphere radius
-         * @param {THREE.Group} group - the instance of THREE group containing the atom mesh
-         * @param {THREE.Mesh} atom - the instance of THREE mesh representing the atom
+         * Calculates a vector from the atom center to the camera clamped to the atom sphere radius.
+         * @param {THREE.Group} group - the instance of THREE group containing the atom mesh;
+         * @param {THREE.Mesh} atom - the instance of THREE mesh representing the atom;
          */
         getClampedVectorToCamera(group, atom) {
             const cellCenter = this.getCellCenter();

--- a/src/mixins/labels.js
+++ b/src/mixins/labels.js
@@ -1,0 +1,115 @@
+import * as THREE from "three";
+
+import { ATOM_GROUP_NAME } from "../enums";
+
+/*
+ * Mixin containing the logic for dealing with atom labes.
+ * Dynamically draws labels over atoms.
+ */
+export const LabelsMixin = (superclass) =>
+    class extends superclass {
+        // eslint-disable-next-line class-methods-use-this
+        createTextTexture(text) {
+            const {
+                fontFace,
+                fontSize,
+                fontWeight,
+                fillColor,
+                strokeColor,
+                strokeLineWidth,
+                textAlign,
+                textBaseline,
+            } = this.settings.labels;
+            const canvas = document.createElement("canvas");
+            const context = canvas.getContext("2d");
+            context.font = `${fontWeight} ${fontSize}px ${fontFace}`;
+            const metrics = context.measureText(text);
+            const textWidth = metrics.width;
+            const basicTextSize = textWidth > fontSize ? textWidth : fontSize;
+            const textSizePowOf2 = 2 ** Math.floor(Math.log2(basicTextSize));
+            const scaledFontSize = (fontSize * textSizePowOf2) / basicTextSize;
+            canvas.width = textSizePowOf2;
+            canvas.height = textSizePowOf2;
+            context.font = `${fontWeight} ${scaledFontSize}px ${fontFace}`;
+            context.textAlign = textAlign;
+            context.textBaseline = textBaseline;
+            context.fillStyle = fillColor;
+            context.strokeStyle = strokeColor;
+            context.lineWidth = strokeLineWidth;
+            context.fillText(text, context.canvas.width / 2, (context.canvas.height / 2) * 1.15);
+            context.strokeText(text, context.canvas.width / 2, (context.canvas.height / 2) * 1.15);
+            const texture = new THREE.Texture(canvas);
+            texture.needsUpdate = true;
+            return texture;
+        }
+
+        createSprite(text, name) {
+            const texture = this.createTextTexture(text);
+            const spriteMaterial = new THREE.SpriteMaterial({ map: texture });
+            const sprite = new THREE.Sprite(spriteMaterial);
+            sprite.name = name;
+            sprite.scale.set(0.25, 0.25, 0.25);
+            sprite.visible = this.areLabelsShown;
+            return sprite;
+        }
+
+        adjustLabelsToCameraPosition() {
+            const { scene, camera } = this;
+            const cellCenter = this.getCellCenter();
+            const atomGroups =
+                scene
+                    .getObjectByName(ATOM_GROUP_NAME)
+                    ?.parent.children.filter((object) => object.name.includes(ATOM_GROUP_NAME)) ||
+                [];
+            atomGroups.forEach((group) => {
+                const labels = group.children.filter((child) => child instanceof THREE.Sprite);
+                labels.forEach((label) => {
+                    const atomUUID = label.name.replace(/label-for-/, "");
+                    const atom = scene.getObjectByProperty("uuid", atomUUID);
+                    const atomRadius = atom.geometry.parameters.radius;
+
+                    const atomPosition = atom.position.clone().add(group.position);
+                    const vectorToCamera = this.isCameraOrthographic
+                        ? new THREE.Vector3(
+                              camera.position.x - cellCenter[0],
+                              camera.position.y - cellCenter[1],
+                              camera.position.z - cellCenter[2],
+                          )
+                        : new THREE.Vector3(
+                              camera.position.x - atomPosition.x,
+                              camera.position.y - atomPosition.y,
+                              camera.position.z - atomPosition.z,
+                          );
+
+                    const clampedVectorToCamera = vectorToCamera
+                        .clone()
+                        .clampLength(atomRadius, atomRadius);
+                    const newLabelPosition = atom.position.clone().add(clampedVectorToCamera);
+                    label.position.copy(newLabelPosition);
+                });
+            });
+        }
+
+        toggleLabels() {
+            this.areLabelsShown = !this.areLabelsShown;
+
+            const { scene } = this;
+            const atomGroups =
+                scene
+                    .getObjectByName(ATOM_GROUP_NAME)
+                    ?.parent.children.filter((object) => object.name.includes(ATOM_GROUP_NAME)) ||
+                [];
+            const labels = atomGroups
+                .map((group) => group.children.filter((child) => child instanceof THREE.Sprite))
+                .flat();
+            labels.forEach((label) => {
+                label.visible = this.areLabelsShown;
+            });
+
+            this.render();
+        }
+
+        createLabel(message, name) {
+            return this.createSprite(message, name);
+        }
+    };

--- a/src/settings.js
+++ b/src/settings.js
@@ -30,13 +30,13 @@ export default {
     initialCameraPosition: [-50, 0, 10],
 
     areLabelsInitiallyShown: false,
-    labels: {
+    labelsConfig: {
         fontFace: "Arial",
         fontSize: 96,
         fontWeight: "Bold",
-        fillColor: "#EEEEEE",
-        strokeColor: "#454545",
-        strokeLineWidth: 2,
+        fillStyle: "#EEEEEE",
+        strokeStyle: "#454545",
+        lineWidth: 2,
         textAlign: "center",
         textBaseline: "middle",
     },

--- a/src/settings.js
+++ b/src/settings.js
@@ -29,6 +29,18 @@ export default {
     defaultColor: "#CCCCCC",
     initialCameraPosition: [-50, 0, 10],
 
+    areLabelsInitiallyShown: false,
+    labels: {
+        fontFace: "Arial",
+        fontSize: 96,
+        fontWeight: "Bold",
+        fillColor: "#EEEEEE",
+        strokeColor: "#454545",
+        strokeLineWidth: 2,
+        textAlign: "center",
+        textBaseline: "middle",
+    },
+
     boundaryConditionTypeColors: {
         bc1: [0xffff00, 0xffff00],
         bc2: [0x0000ff, 0x0000ff],

--- a/src/utils.js
+++ b/src/utils.js
@@ -157,3 +157,14 @@ export function materialsToThreeDSceneData(materials, shift = [2, 0, 0]) {
     }
     return wave.scene.toJSON();
 }
+
+/**
+ * Sets multiple parameters of the target object.
+ * @param {Object} targetObject - the object to receive new property values.
+ * @param {Object} parameters - the object containing key-value pairs to be set.
+ */
+export function setParameters(targetObject, parameters) {
+    Object.keys(parameters).forEach((key) => {
+        targetObject[key] = parameters[key];
+    });
+}

--- a/src/wave.js
+++ b/src/wave.js
@@ -7,6 +7,7 @@ import { BondsMixin } from "./mixins/bonds";
 import { BoundaryMixin } from "./mixins/boundary";
 import { CellMixin } from "./mixins/cell";
 import { ControlsMixin } from "./mixins/controls";
+import { LabelsMixin } from "./mixins/labels";
 import { RepetitionMixin } from "./mixins/repetition";
 import SETTINGS from "./settings";
 // eslint-disable-next-line import/no-cycle
@@ -38,6 +39,7 @@ class WaveBase {
         this.container = DOMElement;
 
         this.updateSettings(settings);
+        this.areLabelsShown = this.settings.areLabelsInitiallyShown;
 
         this.initDimensions();
         this.initRenderer();
@@ -209,6 +211,7 @@ export class Wave extends mix(WaveBase).with(
     RepetitionMixin,
     ControlsMixin,
     BoundaryMixin,
+    LabelsMixin,
 ) {
     /**
      *
@@ -249,6 +252,7 @@ export class Wave extends mix(WaveBase).with(
     }
 
     render() {
+        this.adjustLabelsToCameraPosition(this.scene, this.camera);
         this.renderer.render(this.scene, this.camera);
         if (this.renderer2) this.renderer2.render(this.scene2, this.camera2);
     }

--- a/tests/__tests__/mixins/labels.js
+++ b/tests/__tests__/mixins/labels.js
@@ -16,8 +16,8 @@ describe("Atom labels", () => {
         expect(atoms.length).toEqual(basisAtomsNumber);
         expect(labels.length).toEqual(basisAtomsNumber);
         expect(
-            labels.every((label) =>
-                atoms.find((atom) => atom.uuid === label.name.replace("label-for-", "")),
+            atoms.every((atom) =>
+                labels.find((label) => atom.uuid === label.name.replace("label-for-", "")),
             ),
         );
     });
@@ -34,6 +34,7 @@ describe("Atom labels", () => {
     });
 
     test("Label center is positioned on the atom surface", () => {
+        wave.toggleLabels();
         expect(
             labels.every((label) => {
                 const atom = atoms.find((a) => a.uuid === label.name.replace("label-for-", ""));

--- a/tests/__tests__/mixins/labels.js
+++ b/tests/__tests__/mixins/labels.js
@@ -1,0 +1,45 @@
+import { ATOM_GROUP_NAME } from "../../../src/enums";
+import { getWaveInstance } from "../../enums";
+
+describe("Atom labels", () => {
+    let wave, atoms, labels;
+
+    beforeEach(() => {
+        wave = getWaveInstance();
+        const atomGroup = wave.scene.getObjectByName(ATOM_GROUP_NAME);
+        atoms = atomGroup.children.filter((object) => object.type === "Mesh");
+        labels = atomGroup.children.filter((object) => object.type === "Sprite");
+    });
+
+    test("Labels are created for every atom", async () => {
+        const basisAtomsNumber = wave.structure.basis.elements.length;
+        expect(atoms.length).toEqual(basisAtomsNumber);
+        expect(labels.length).toEqual(basisAtomsNumber);
+        expect(
+            labels.every((label) =>
+                atoms.find((atom) => atom.uuid === label.name.replace("label-for-", "")),
+            ),
+        );
+    });
+
+    test("Initial labels visibility matches the settings", async () => {
+        const { areLabelsInitiallyShown } = wave.settings;
+        expect(labels.every((label) => label.visible === areLabelsInitiallyShown)).toBeTruthy();
+    });
+
+    test("Labels visibility can be toggled", () => {
+        const { areLabelsInitiallyShown } = wave.settings;
+        wave.toggleLabels();
+        expect(labels.every((label) => label.visible === !areLabelsInitiallyShown)).toBeTruthy();
+    });
+
+    test("Label center is positioned on the atom surface", () => {
+        expect(
+            labels.every((label) => {
+                const atom = atoms.find((a) => a.uuid === label.name.replace("label-for-", ""));
+                const distanceToCenter = label.position.distanceTo(atom.position);
+                return Math.abs(distanceToCenter - atom.geometry.parameters.radius) < 0.00001;
+            }),
+        ).toBeTruthy();
+    });
+});

--- a/tests/setupFiles.js
+++ b/tests/setupFiles.js
@@ -1,3 +1,5 @@
+import "jest-canvas-mock";
+
 import { configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import expect from "expect";


### PR DESCRIPTION
Atom labeling working for repetitions + on/off controls; tests for labels only check the sprite attributes, and do not generate snapshots.