### PR TITLE
chore: consume cove.js from @mat3ra scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ In case you need to link Cove.js into the app for local development you need
 
 1. Add local path of Cove.js to package.json
 ```bash
-    "@mat3ra/cove.js": "file:../../cove.js"
+    "@mat3ra/cove": "file:../../cove.js"
 ```
 2. Run the app
 ```bash

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ In case you need to link Cove.js into the app for local development you need
 
 1. Add local path of Cove.js to package.json
 ```bash
-    "@exabyte-io/cove.js": "file:../../cove.js"
+    "@mat3ra/cove.js": "file:../../cove.js"
 ```
 2. Run the app
 ```bash

--- a/dist/components/IconsToolbar.d.ts
+++ b/dist/components/IconsToolbar.d.ts
@@ -1,4 +1,4 @@
-import { NestedDropdownAction, NestedDropdownProps } from "@exabyte-io/cove.js/dist/mui/components/nested-dropdown/NestedDropdown";
+import { NestedDropdownAction, NestedDropdownProps } from "@mat3ra/cove.js/dist/mui/components/nested-dropdown/NestedDropdown";
 import React from "react";
 interface ToolbarConfig {
     id: string;

--- a/dist/components/IconsToolbar.d.ts
+++ b/dist/components/IconsToolbar.d.ts
@@ -1,4 +1,4 @@
-import { NestedDropdownAction, NestedDropdownProps } from "@mat3ra/cove.js/dist/mui/components/nested-dropdown/NestedDropdown";
+import { NestedDropdownAction, NestedDropdownProps } from "@mat3ra/cove/dist/mui/components/nested-dropdown/NestedDropdown";
 import React from "react";
 interface ToolbarConfig {
     id: string;

--- a/dist/components/IconsToolbar.js
+++ b/dist/components/IconsToolbar.js
@@ -1,7 +1,7 @@
 import { createElement as _createElement } from "react";
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-import IconByName from "@mat3ra/cove.js/dist/mui/components/icon";
-import NestedDropdown from "@mat3ra/cove.js/dist/mui/components/nested-dropdown/NestedDropdown";
+import IconByName from "@mat3ra/cove/dist/mui/components/icon";
+import NestedDropdown from "@mat3ra/cove/dist/mui/components/nested-dropdown/NestedDropdown";
 import PowerSettingsNew from "@mui/icons-material/PowerSettingsNew";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import Paper from "@mui/material/Paper";

--- a/dist/components/IconsToolbar.js
+++ b/dist/components/IconsToolbar.js
@@ -1,7 +1,7 @@
 import { createElement as _createElement } from "react";
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-import IconByName from "@exabyte-io/cove.js/dist/mui/components/icon";
-import NestedDropdown from "@exabyte-io/cove.js/dist/mui/components/nested-dropdown/NestedDropdown";
+import IconByName from "@mat3ra/cove.js/dist/mui/components/icon";
+import NestedDropdown from "@mat3ra/cove.js/dist/mui/components/nested-dropdown/NestedDropdown";
 import PowerSettingsNew from "@mui/icons-material/PowerSettingsNew";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import Paper from "@mui/material/Paper";

--- a/dist/components/ModalDialog.js
+++ b/dist/components/ModalDialog.js
@@ -1,5 +1,5 @@
 import { jsx as _jsx } from "react/jsx-runtime";
-import Dialog from "@mat3ra/cove.js/dist/mui/components/dialog/Dialog";
+import Dialog from "@mat3ra/cove/dist/mui/components/dialog/Dialog";
 import PropTypes from "prop-types";
 import React from "react";
 export class ModalDialog extends React.Component {

--- a/dist/components/ModalDialog.js
+++ b/dist/components/ModalDialog.js
@@ -1,5 +1,5 @@
 import { jsx as _jsx } from "react/jsx-runtime";
-import Dialog from "@exabyte-io/cove.js/dist/mui/components/dialog/Dialog";
+import Dialog from "@mat3ra/cove.js/dist/mui/components/dialog/Dialog";
 import PropTypes from "prop-types";
 import React from "react";
 export class ModalDialog extends React.Component {

--- a/dist/components/ThreeDEditor.js
+++ b/dist/components/ThreeDEditor.js
@@ -1,10 +1,10 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 /* eslint-disable react/sort-comp */
 // import "../MuiClassNameSetup";
-import { DarkMaterialUITheme } from "@mat3ra/cove.js/dist/theme";
-import ThemeProvider from "@mat3ra/cove.js/dist/theme/provider";
-import { exportToDisk } from "@mat3ra/cove.js/dist/utils/downloader";
-import { AlertProvider } from "@mat3ra/cove.js/src/theme/provider";
+import { DarkMaterialUITheme } from "@mat3ra/cove/dist/theme";
+import ThemeProvider from "@mat3ra/cove/dist/theme/provider";
+import { exportToDisk } from "@mat3ra/cove/dist/utils/downloader";
+import { AlertProvider } from "@mat3ra/cove/src/theme/provider";
 import { Made } from "@mat3ra/made";
 import Article from "@mui/icons-material/Article";
 import Autorenew from "@mui/icons-material/Autorenew";

--- a/dist/components/ThreeDEditor.js
+++ b/dist/components/ThreeDEditor.js
@@ -1,10 +1,10 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 /* eslint-disable react/sort-comp */
 // import "../MuiClassNameSetup";
-import { DarkMaterialUITheme } from "@exabyte-io/cove.js/dist/theme";
-import ThemeProvider from "@exabyte-io/cove.js/dist/theme/provider";
-import { exportToDisk } from "@exabyte-io/cove.js/dist/utils/downloader";
-import { AlertProvider } from "@exabyte-io/cove.js/src/theme/provider";
+import { DarkMaterialUITheme } from "@mat3ra/cove.js/dist/theme";
+import ThemeProvider from "@mat3ra/cove.js/dist/theme/provider";
+import { exportToDisk } from "@mat3ra/cove.js/dist/utils/downloader";
+import { AlertProvider } from "@mat3ra/cove.js/src/theme/provider";
 import { Made } from "@mat3ra/made";
 import Article from "@mui/icons-material/Article";
 import Autorenew from "@mui/icons-material/Autorenew";

--- a/dist/mixins/image.js
+++ b/dist/mixins/image.js
@@ -1,5 +1,5 @@
-import { showInfoAlert, showSuccessAlert, showWarningAlert, } from "@exabyte-io/cove.js/dist/other/alerts";
-import { saveImageDataToFile } from "@exabyte-io/cove.js/dist/utils/downloader";
+import { showInfoAlert, showSuccessAlert, showWarningAlert, } from "@mat3ra/cove.js/dist/other/alerts";
+import { saveImageDataToFile } from "@mat3ra/cove.js/dist/utils/downloader";
 import { createGIFAsync } from "./utils";
 export const ImageMixin = (superclass) => class extends superclass {
     takeScreenshot() {

--- a/dist/mixins/image.js
+++ b/dist/mixins/image.js
@@ -1,5 +1,5 @@
-import { showInfoAlert, showSuccessAlert, showWarningAlert, } from "@mat3ra/cove.js/dist/other/alerts";
-import { saveImageDataToFile } from "@mat3ra/cove.js/dist/utils/downloader";
+import { showInfoAlert, showSuccessAlert, showWarningAlert } from "@mat3ra/cove/dist/other/alerts";
+import { saveImageDataToFile } from "@mat3ra/cove/dist/utils/downloader";
 import { createGIFAsync } from "./utils";
 export const ImageMixin = (superclass) => class extends superclass {
     takeScreenshot() {

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,7 @@ module.exports = {
         "^.+\\.[t|j]sx?$": "babel-jest",
     },
 
-    transformIgnorePatterns: ["<rootDir>/node_modules/(?!(three|color-diff|@mat3ra/cove.js)/)"],
+    transformIgnorePatterns: ["<rootDir>/node_modules/(?!(three|color-diff|@mat3ra/cove)/)"],
 
     // mock css files: https://jestjs.io/docs/en/webpack#handling-static-assets
     moduleNameMapper: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,7 @@ module.exports = {
         "^.+\\.[t|j]sx?$": "babel-jest",
     },
 
-    transformIgnorePatterns: ["<rootDir>/node_modules/(?!(three|color-diff|@exabyte-io/cove.js)/)"],
+    transformIgnorePatterns: ["<rootDir>/node_modules/(?!(three|color-diff|@mat3ra/cove.js)/)"],
 
     // mock css files: https://jestjs.io/docs/en/webpack#handling-static-assets
     moduleNameMapper: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
             "devDependencies": {
                 "@exabyte-io/eslint-config": "^2025.1.15-0",
                 "@mat3ra/code": "2025.4.27-0",
-                "@mat3ra/cove.js": "2026.7.18-1",
+                "@mat3ra/cove": "2026.7.18-4",
                 "@mat3ra/esse": "2025.4.22-0",
                 "@mat3ra/made": "2025.6.25-1",
                 "@mat3ra/tsconfig": "^2024.6.3-0",
@@ -88,7 +88,7 @@
             },
             "peerDependencies": {
                 "@mat3ra/code": "*",
-                "@mat3ra/cove.js": "*",
+                "@mat3ra/cove": "*",
                 "@mat3ra/esse": "*",
                 "@mat3ra/made": "*",
                 "@mat3ra/utils": "*",
@@ -3966,10 +3966,10 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@mat3ra/cove.js": {
-            "version": "2026.7.18-1",
-            "resolved": "https://registry.npmjs.org/@mat3ra/cove.js/-/cove.js-2026.7.18-1.tgz",
-            "integrity": "sha512-WzxaULMFmsLf9yMnjckgYXX9jQHZ5xpwEqSPOA7frvSdkyqNTitXOez+b/8C5ZdwGZtcpll7Qleb5t9oiixRgA==",
+        "node_modules/@mat3ra/cove": {
+            "version": "2026.7.18-4",
+            "resolved": "https://registry.npmjs.org/@mat3ra/cove/-/cove-2026.7.18-4.tgz",
+            "integrity": "sha512-RKMMosc5yo9xhymWUD9AlzllULbf079d19E5Zb5nt9poufrYbNoiUQT1wst1I6uDfbGZrlwxbspFEl5pjVAPNw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -4028,7 +4028,7 @@
                 "underscore": "^1.8.3"
             }
         },
-        "node_modules/@mat3ra/cove.js/node_modules/@babel/eslint-parser": {
+        "node_modules/@mat3ra/cove/node_modules/@babel/eslint-parser": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
             "integrity": "sha512-zxt+UJTOMKvUt3yOg+D58MLuz334pHp93qifMFcjIIO+9hN6t+ufw2gi7vDPMpxvfnHRR+3VVXvIjineCcgyXw==",
@@ -4047,7 +4047,7 @@
                 "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
             }
         },
-        "node_modules/@mat3ra/cove.js/node_modules/semver": {
+        "node_modules/@mat3ra/cove/node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
@@ -4057,7 +4057,7 @@
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/@mat3ra/cove.js/node_modules/typescript": {
+        "node_modules/@mat3ra/cove/node_modules/typescript": {
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
                 "underscore.string": "^3.3.4"
             },
             "devDependencies": {
-                "@exabyte-io/cove.js": "2025.2.22-0",
                 "@exabyte-io/eslint-config": "^2025.1.15-0",
                 "@mat3ra/code": "2025.4.27-0",
+                "@mat3ra/cove.js": "2026.7.18-1",
                 "@mat3ra/esse": "2025.4.22-0",
                 "@mat3ra/made": "2025.6.25-1",
                 "@mat3ra/tsconfig": "^2024.6.3-0",
@@ -87,8 +87,8 @@
                 "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "@exabyte-io/cove.js": "*",
                 "@mat3ra/code": "*",
+                "@mat3ra/cove.js": "*",
                 "@mat3ra/esse": "*",
                 "@mat3ra/made": "*",
                 "@mat3ra/utils": "*",
@@ -546,6 +546,7 @@
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
             "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.24.7",
                 "chalk": "^2.4.2",
@@ -2450,9 +2451,9 @@
             }
         },
         "node_modules/@codemirror/view": {
-            "version": "6.36.2",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.2.tgz",
-            "integrity": "sha512-DZ6ONbs8qdJK0fdN7AB82CgI6tYXf4HWk1wSVa0+9bhVznCuuvhQtX8bFBoy3dv8rZSQqUd8GvhVAcielcidrA==",
+            "version": "6.36.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.3.tgz",
+            "integrity": "sha512-N2bilM47QWC8Hnx0rMdDxO2x2ImJ1FvZWXubwKgjeoOrWwEiFrtpA7SFHcuZ+o2Ze2VzbkgbzWVj4+V18LVkeg==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.5.0",
@@ -3225,6 +3226,7 @@
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
             "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+            "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.1.1",
@@ -3244,6 +3246,7 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -3260,6 +3263,7 @@
             "version": "13.24.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
             "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+            "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -3274,6 +3278,7 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "dev": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -3282,121 +3287,20 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/type-fest": {
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@exabyte-io/cove.js": {
-            "version": "2025.2.22-0",
-            "resolved": "https://registry.npmjs.org/@exabyte-io/cove.js/-/cove.js-2025.2.22-0.tgz",
-            "integrity": "sha512-+9BCffFLaupwRa7/rkpxIFINMfjlIuz4eVGWoxt0LPhAMnqoA3iwwYgYTwWuT55HNf0ikeRRUmyrCx19ULz8Rg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/eslint-parser": "^7.26.5",
-                "@codemirror/autocomplete": "^6.18.4",
-                "@codemirror/lang-javascript": "^6.2.2",
-                "@codemirror/lang-json": "^6.0.1",
-                "@codemirror/lang-python": "6.1.6",
-                "@codemirror/language": "^6.10.8",
-                "@codemirror/legacy-modes": "^6.4.2",
-                "@codemirror/lint": "^6.8.4",
-                "@codemirror/state": "^6.5.1",
-                "@codemirror/view": "^6.36.2",
-                "@mui/x-date-pickers": "6.11.1",
-                "@rjsf/core": "^5.24.1",
-                "@rjsf/mui": "^5.24.1",
-                "@rjsf/utils": "^5.24.1",
-                "@rjsf/validator-ajv8": "^5.24.1",
-                "@toast-ui/editor": "^3.2.2",
-                "@toast-ui/editor-plugin-code-syntax-highlight": "^3.1.0",
-                "@toast-ui/react-editor": "^3.2.3",
-                "@types/classnames": "^2.3.4",
-                "@types/katex": "^0.16.7",
-                "@types/prismjs": "^1.26.5",
-                "@types/react-beautiful-dnd": "^13.1.8",
-                "@types/underscore.string": "0.0.41",
-                "@uiw/react-codemirror": "^4.23.7",
-                "jszip": "^3.10.1",
-                "jszip-utils": "0.1.0",
-                "katex": "^0.16.21",
-                "notistack": "^3.0.1",
-                "prismjs": "^1.29.0",
-                "react-beautiful-dnd": "^13.1.1",
-                "react-draggable": "^4.4.6",
-                "react-full-screen": "^1.1.1",
-                "react-json-view": "^1.21.3",
-                "typescript": "^4.9.5",
-                "underscore.string": "^3.3.6"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "@mat3ra/code": "*",
-                "@mat3ra/esse": "*",
-                "@mui/icons-material": "^5.11.9",
-                "@mui/lab": "^5.0.0-alpha.120",
-                "@mui/material": "^5.11.9",
-                "@mui/styles": "^5.11.9",
-                "classnames": "^2.3.2",
-                "moment": "^2.29.4",
-                "prop-types": "^15.8.1",
-                "react": "^17.0.0",
-                "react-dom": "^17.0.0",
-                "underscore": "^1.8.3"
-            }
-        },
-        "node_modules/@exabyte-io/cove.js/node_modules/@babel/eslint-parser": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.26.5.tgz",
-            "integrity": "sha512-Kkm8C8uxI842AwQADxl0GbcG1rupELYLShazYEZO/2DYjhyWXJIOUVOE3tBYm6JXzUCNJOZEzqc4rCW/jsEQYQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-                "eslint-visitor-keys": "^2.1.0",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.11.0",
-                "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
-            }
-        },
-        "node_modules/@exabyte-io/cove.js/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@exabyte-io/cove.js/node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
             }
         },
         "node_modules/@exabyte-io/eslint-config": {
@@ -3471,6 +3375,7 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
             "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
             "deprecated": "Use @eslint/config-array instead",
+            "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.0",
                 "debug": "^4.1.1",
@@ -3484,7 +3389,8 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "deprecated": "Use @eslint/object-schema instead"
+            "deprecated": "Use @eslint/object-schema instead",
+            "dev": true
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
@@ -4058,6 +3964,111 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/@mat3ra/cove.js": {
+            "version": "2026.7.18-1",
+            "resolved": "https://registry.npmjs.org/@mat3ra/cove.js/-/cove.js-2026.7.18-1.tgz",
+            "integrity": "sha512-WzxaULMFmsLf9yMnjckgYXX9jQHZ5xpwEqSPOA7frvSdkyqNTitXOez+b/8C5ZdwGZtcpll7Qleb5t9oiixRgA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/eslint-parser": "^7.26.5",
+                "@codemirror/autocomplete": "^6.18.4",
+                "@codemirror/lang-javascript": "^6.2.2",
+                "@codemirror/lang-json": "^6.0.1",
+                "@codemirror/lang-python": "6.1.6",
+                "@codemirror/language": "^6.10.8",
+                "@codemirror/legacy-modes": "^6.4.2",
+                "@codemirror/lint": "6.8.4",
+                "@codemirror/state": "^6.5.1",
+                "@codemirror/view": "6.36.3",
+                "@mui/x-date-pickers": "6.11.1",
+                "@rjsf/core": "^5.24.13",
+                "@rjsf/mui": "^5.24.13",
+                "@rjsf/utils": "^5.24.13",
+                "@rjsf/validator-ajv8": "^5.24.13",
+                "@toast-ui/editor": "^3.2.2",
+                "@toast-ui/editor-plugin-code-syntax-highlight": "^3.1.0",
+                "@toast-ui/react-editor": "^3.2.3",
+                "@types/classnames": "^2.3.4",
+                "@types/katex": "^0.16.7",
+                "@types/prismjs": "^1.26.5",
+                "@types/react-beautiful-dnd": "^13.1.8",
+                "@types/underscore.string": "0.0.41",
+                "@uiw/react-codemirror": "^4.23.7",
+                "jszip": "^3.10.1",
+                "jszip-utils": "0.1.0",
+                "katex": "^0.16.21",
+                "lodash": "^4.17.21",
+                "notistack": "^3.0.1",
+                "prismjs": "^1.29.0",
+                "react-beautiful-dnd": "^13.1.1",
+                "react-draggable": "^4.4.6",
+                "react-full-screen": "^1.1.1",
+                "react-json-view": "^1.21.3",
+                "typescript": "^4.9.5",
+                "underscore.string": "^3.3.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@mat3ra/code": "*",
+                "@mat3ra/esse": "*",
+                "@mui/icons-material": "^5.11.9",
+                "@mui/lab": "^5.0.0-alpha.120",
+                "@mui/material": "^5.11.9",
+                "@mui/styles": "^5.11.9",
+                "classnames": "^2.3.2",
+                "moment": "^2.29.4",
+                "prop-types": "^15.8.1",
+                "react": "^17.0.0",
+                "react-dom": "^17.0.0",
+                "underscore": "^1.8.3"
+            }
+        },
+        "node_modules/@mat3ra/cove.js/node_modules/@babel/eslint-parser": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
+            "integrity": "sha512-zxt+UJTOMKvUt3yOg+D58MLuz334pHp93qifMFcjIIO+9hN6t+ufw2gi7vDPMpxvfnHRR+3VVXvIjineCcgyXw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
+                "eslint-visitor-keys": "^2.1.0",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.11.0",
+                "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
+            }
+        },
+        "node_modules/@mat3ra/cove.js/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@mat3ra/cove.js/node_modules/typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
             }
         },
         "node_modules/@mat3ra/esse": {
@@ -5387,16 +5398,15 @@
             }
         },
         "node_modules/@rjsf/core": {
-            "version": "5.24.1",
-            "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.24.1.tgz",
-            "integrity": "sha512-x3oZ9MfoBA4SPKhvNkqagqnjUbSKuT3gGW3NgH+cowAma33fYs9/hfhPUOvXySdPqh0layuLlnI1W5MHeBmVzg==",
+            "version": "5.24.13",
+            "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.24.13.tgz",
+            "integrity": "sha512-ONTr14s7LFIjx2VRFLuOpagL76sM/HPy6/OhdBfq6UukINmTIs6+aFN0GgcR0aXQHFDXQ7f/fel0o/SO05Htdg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "lodash": "^4.17.21",
                 "lodash-es": "^4.17.21",
                 "markdown-to-jsx": "^7.4.1",
-                "nanoid": "^3.3.7",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -5408,9 +5418,9 @@
             }
         },
         "node_modules/@rjsf/mui": {
-            "version": "5.24.1",
-            "resolved": "https://registry.npmjs.org/@rjsf/mui/-/mui-5.24.1.tgz",
-            "integrity": "sha512-yDloYZnwg/PYtjaQTBDSmW/nGeM+9koyngmST7LRCTe3yB2uQ4p4UYAMCG4chehWCxPO2zDowYMjejmYE6cfdg==",
+            "version": "5.24.13",
+            "resolved": "https://registry.npmjs.org/@rjsf/mui/-/mui-5.24.13.tgz",
+            "integrity": "sha512-KGh90HRGkU1OIvnkB9IOOXYqpzgxkduQYwPq3oj9Wl4KcNdFsfGjGofqSfvrO68mNfrDE4ouAD4MPePTVEtKyg==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -5427,9 +5437,9 @@
             }
         },
         "node_modules/@rjsf/utils": {
-            "version": "5.24.1",
-            "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.24.1.tgz",
-            "integrity": "sha512-A25fFj/TNz5bKikCIs20DiedKAalLuAQ7vUX9VQkD2hps5C9YVr0dJgSlsPa5kzl6lQMaRsNouTx8E1ZdLV2fg==",
+            "version": "5.24.13",
+            "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.24.13.tgz",
+            "integrity": "sha512-rNF8tDxIwTtXzz5O/U23QU73nlhgQNYJ+Sv5BAwQOIyhIE2Z3S5tUiSVMwZHt0julkv/Ryfwi+qsD4FiE5rOuw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -5454,9 +5464,9 @@
             "license": "MIT"
         },
         "node_modules/@rjsf/validator-ajv8": {
-            "version": "5.24.1",
-            "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-5.24.1.tgz",
-            "integrity": "sha512-p6URehglU9yFUAoQXE1ryqZjLYSjc6qdbiUfCVvEFAzUuMECsIFomz2hH3CPlt10K72sAFdzwVvrKn1iWTnxDw==",
+            "version": "5.24.13",
+            "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-5.24.13.tgz",
+            "integrity": "sha512-oWHP7YK581M8I5cF1t+UXFavnv+bhcqjtL1a7MG/Kaffi0EwhgcYjODrD8SsnrhncsEYMqSECr4ZOEoirnEUWw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -7272,6 +7282,7 @@
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
             "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -7294,6 +7305,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -7335,6 +7347,7 @@
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -7380,6 +7393,7 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
             "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -7415,6 +7429,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7423,6 +7438,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -7469,6 +7485,7 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -7476,7 +7493,8 @@
         "node_modules/argparse/node_modules/sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true
         },
         "node_modules/array-almost-equal": {
             "version": "1.0.0",
@@ -7694,6 +7712,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8466,6 +8485,7 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -9012,6 +9032,7 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
             "dependencies": {
                 "color-name": "1.1.3"
             }
@@ -9026,7 +9047,8 @@
         "node_modules/color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
         },
         "node_modules/color-string": {
             "version": "1.9.1",
@@ -9313,6 +9335,7 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -9572,7 +9595,8 @@
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -9706,6 +9730,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
             "dependencies": {
                 "esutils": "^2.0.2"
             },
@@ -9841,7 +9866,8 @@
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "node_modules/encoding": {
             "version": "0.1.13",
@@ -9867,6 +9893,7 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
             "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+            "dev": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1",
                 "strip-ansi": "^6.0.1"
@@ -10252,6 +10279,7 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -10304,6 +10332,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
             "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
                 "@eslint/eslintrc": "^0.4.3",
@@ -10415,47 +10444,6 @@
             },
             "peerDependencies": {
                 "eslint": ">=7.0.0"
-            }
-        },
-        "node_modules/eslint-import-resolver-exports": {
-            "version": "1.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-exports/-/eslint-import-resolver-exports-1.0.0-beta.5.tgz",
-            "integrity": "sha512-o6t0w7muUpXr7MkUVzD5igQoDfAQvTmcPp8HEAJdNF8eOuAO+yn6I/TTyMxz9ecCwzX7e02vzlkHURoScUuidg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "resolve.exports": "^2.0.0"
-            },
-            "peerDependencies": {
-                "eslint": "*",
-                "eslint-plugin-import": "*"
-            }
-        },
-        "node_modules/eslint-import-resolver-exports/node_modules/resolve.exports": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
-            "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/eslint-import-resolver-meteor": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-meteor/-/eslint-import-resolver-meteor-0.4.0.tgz",
-            "integrity": "sha512-BSqvgt6QZvk9EGhDGnM4azgbxyBD8b0y6FYA52WFzpWpHcZV9ys8PxM33bx8dlCy3HyopRLLsMUnlhTpZzsZmQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "object-assign": "^4.0.1",
-                "resolve": "^1.1.6"
-            },
-            "peerDependencies": {
-                "eslint-plugin-import": ">=1.4.0"
             }
         },
         "node_modules/eslint-import-resolver-node": {
@@ -10780,20 +10768,6 @@
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
             }
         },
-        "node_modules/eslint-plugin-react-hooks": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-            "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
-            }
-        },
         "node_modules/eslint-plugin-react/node_modules/doctrine": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -10878,6 +10852,7 @@
             "version": "7.12.11",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
             "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+            "dev": true,
             "dependencies": {
                 "@babel/highlight": "^7.10.4"
             }
@@ -10886,6 +10861,7 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -10902,6 +10878,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -10916,6 +10893,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -10931,6 +10909,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -10941,12 +10920,14 @@
         "node_modules/eslint/node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "node_modules/eslint/node_modules/escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -10958,6 +10939,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
             "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+            "dev": true,
             "dependencies": {
                 "eslint-visitor-keys": "^1.1.0"
             },
@@ -10972,6 +10954,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
             "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -10980,6 +10963,7 @@
             "version": "13.24.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
             "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+            "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -10994,6 +10978,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -11002,6 +10987,7 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "dev": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -11010,12 +10996,14 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/levn": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -11028,6 +11016,7 @@
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+            "dev": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -11044,6 +11033,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -11052,6 +11042,7 @@
             "version": "7.6.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
             "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -11063,6 +11054,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -11074,6 +11066,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -11085,6 +11078,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
@@ -11112,6 +11106,7 @@
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
             "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+            "dev": true,
             "dependencies": {
                 "acorn": "^7.4.0",
                 "acorn-jsx": "^5.3.1",
@@ -11125,6 +11120,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
             "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -11133,6 +11129,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true,
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -11145,6 +11142,7 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
             "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+            "dev": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -11156,6 +11154,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -11461,7 +11460,8 @@
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
         },
         "node_modules/fast-diff": {
             "version": "1.3.0",
@@ -11495,17 +11495,20 @@
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+            "dev": true
         },
         "node_modules/fast-uri": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-            "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
+            "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+            "dev": true
         },
         "node_modules/fastq": {
             "version": "1.17.1",
@@ -11575,6 +11578,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+            "dev": true,
             "dependencies": {
                 "flat-cache": "^3.0.4"
             },
@@ -11633,6 +11637,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
             "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+            "dev": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.3",
@@ -11645,7 +11650,8 @@
         "node_modules/flatted": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
+            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+            "dev": true
         },
         "node_modules/flux": {
             "version": "4.0.4",
@@ -11828,7 +11834,8 @@
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="
+            "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+            "dev": true
         },
         "node_modules/functions-have-names": {
             "version": "1.2.3",
@@ -12002,6 +12009,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "devOptional": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -12221,6 +12229,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -12606,6 +12615,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -12861,6 +12871,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12885,6 +12896,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -12921,6 +12933,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "devOptional": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -13243,7 +13256,8 @@
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
         },
         "node_modules/isobject": {
             "version": "3.0.1",
@@ -15388,6 +15402,7 @@
             "version": "3.14.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
             "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -15469,7 +15484,8 @@
         "node_modules/json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -15583,12 +15599,14 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+            "dev": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -15768,6 +15786,7 @@
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -16071,12 +16090,14 @@
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
+            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+            "dev": true
         },
         "node_modules/log-update": {
             "version": "4.0.0",
@@ -16740,7 +16761,8 @@
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+            "dev": true
         },
         "node_modules/natural-compare-lite": {
             "version": "1.4.0",
@@ -17739,6 +17761,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -18065,6 +18088,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -18239,6 +18263,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -18391,6 +18416,7 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
             "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -18435,6 +18461,7 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
             "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -18789,6 +18816,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
             "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             },
@@ -18852,6 +18880,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -18979,6 +19008,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -19224,6 +19254,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
             "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -19424,6 +19455,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -19436,6 +19468,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -19631,6 +19664,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
             "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -19647,6 +19681,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -19661,6 +19696,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -19671,7 +19707,8 @@
         "node_modules/slice-ansi/node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
@@ -19957,6 +19994,7 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -20083,6 +20121,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -20126,6 +20165,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             },
@@ -20147,6 +20187,7 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -20240,6 +20281,7 @@
             "version": "6.8.2",
             "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
             "integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
+            "dev": true,
             "dependencies": {
                 "ajv": "^8.0.1",
                 "lodash.truncate": "^4.4.2",
@@ -20416,7 +20458,8 @@
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+            "dev": true
         },
         "node_modules/thenify": {
             "version": "3.3.1",
@@ -21127,6 +21170,7 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
@@ -21244,7 +21288,8 @@
         "node_modules/v8-compile-cache": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
-            "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw=="
+            "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==",
+            "dev": true
         },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
@@ -21566,6 +21611,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -21669,6 +21715,7 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "start": "vite",
         "transpile": "tsc && npm run copy-css",
         "copy-css": "mkdir -p dist/stylesheets && cp src/stylesheets/* dist/stylesheets/",
-        "prestart": "npm-link-shared ./node_modules/@exabyte-io/cove.js/node_modules . react",
+        "prestart": "npm-link-shared ./node_modules/@mat3ra/cove.js/node_modules . react",
         "test": "npx jest",
         "lint": "eslint src tests",
         "lint:fix": "eslint --fix --cache src tests",
@@ -52,7 +52,7 @@
         "underscore.string": "^3.3.4"
     },
     "peerDependencies": {
-        "@exabyte-io/cove.js": "*",
+        "@mat3ra/cove.js": "*",
         "@mat3ra/code": "*",
         "@mat3ra/esse": "*",
         "@mat3ra/made": "*",
@@ -61,7 +61,7 @@
         "react-dom": "^17.0.0"
     },
     "devDependencies": {
-        "@exabyte-io/cove.js": "2025.2.22-0",
+        "@mat3ra/cove.js": "2026.7.18-1",
         "@exabyte-io/eslint-config": "^2025.1.15-0",
         "@mat3ra/code": "2025.4.27-0",
         "@mat3ra/esse": "2025.4.22-0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "start": "vite",
         "transpile": "tsc && npm run copy-css",
         "copy-css": "mkdir -p dist/stylesheets && cp src/stylesheets/* dist/stylesheets/",
-        "prestart": "npm-link-shared ./node_modules/@mat3ra/cove.js/node_modules . react",
+        "prestart": "npm-link-shared ./node_modules/@mat3ra/cove/node_modules . react",
         "test": "npx jest",
         "lint": "eslint src tests",
         "lint:fix": "eslint --fix --cache src tests",
@@ -52,7 +52,7 @@
         "underscore.string": "^3.3.4"
     },
     "peerDependencies": {
-        "@mat3ra/cove.js": "*",
+        "@mat3ra/cove": "*",
         "@mat3ra/code": "*",
         "@mat3ra/esse": "*",
         "@mat3ra/made": "*",
@@ -61,7 +61,7 @@
         "react-dom": "^17.0.0"
     },
     "devDependencies": {
-        "@mat3ra/cove.js": "2026.7.18-1",
+        "@mat3ra/cove": "2026.7.18-4",
         "@exabyte-io/eslint-config": "^2025.1.15-0",
         "@mat3ra/code": "2025.4.27-0",
         "@mat3ra/esse": "2025.4.22-0",

--- a/src/components/IconsToolbar.tsx
+++ b/src/components/IconsToolbar.tsx
@@ -1,8 +1,8 @@
-import IconByName from "@exabyte-io/cove.js/dist/mui/components/icon";
+import IconByName from "@mat3ra/cove.js/dist/mui/components/icon";
 import NestedDropdown, {
     NestedDropdownAction,
     NestedDropdownProps,
-} from "@exabyte-io/cove.js/dist/mui/components/nested-dropdown/NestedDropdown";
+} from "@mat3ra/cove.js/dist/mui/components/nested-dropdown/NestedDropdown";
 import PowerSettingsNew from "@mui/icons-material/PowerSettingsNew";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import Paper from "@mui/material/Paper";

--- a/src/components/IconsToolbar.tsx
+++ b/src/components/IconsToolbar.tsx
@@ -1,8 +1,8 @@
-import IconByName from "@mat3ra/cove.js/dist/mui/components/icon";
+import IconByName from "@mat3ra/cove/dist/mui/components/icon";
 import NestedDropdown, {
     NestedDropdownAction,
     NestedDropdownProps,
-} from "@mat3ra/cove.js/dist/mui/components/nested-dropdown/NestedDropdown";
+} from "@mat3ra/cove/dist/mui/components/nested-dropdown/NestedDropdown";
 import PowerSettingsNew from "@mui/icons-material/PowerSettingsNew";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import Paper from "@mui/material/Paper";

--- a/src/components/ModalDialog.jsx
+++ b/src/components/ModalDialog.jsx
@@ -1,4 +1,4 @@
-import Dialog from "@mat3ra/cove.js/dist/mui/components/dialog/Dialog";
+import Dialog from "@mat3ra/cove/dist/mui/components/dialog/Dialog";
 import PropTypes from "prop-types";
 import React from "react";
 

--- a/src/components/ModalDialog.jsx
+++ b/src/components/ModalDialog.jsx
@@ -1,4 +1,4 @@
-import Dialog from "@exabyte-io/cove.js/dist/mui/components/dialog/Dialog";
+import Dialog from "@mat3ra/cove.js/dist/mui/components/dialog/Dialog";
 import PropTypes from "prop-types";
 import React from "react";
 

--- a/src/components/ThreeDEditor.jsx
+++ b/src/components/ThreeDEditor.jsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/sort-comp */
 // import "../MuiClassNameSetup";
 
-import { DarkMaterialUITheme } from "@exabyte-io/cove.js/dist/theme";
-import ThemeProvider from "@exabyte-io/cove.js/dist/theme/provider";
-import { exportToDisk } from "@exabyte-io/cove.js/dist/utils/downloader";
-import { AlertProvider } from "@exabyte-io/cove.js/src/theme/provider";
+import { DarkMaterialUITheme } from "@mat3ra/cove.js/dist/theme";
+import ThemeProvider from "@mat3ra/cove.js/dist/theme/provider";
+import { exportToDisk } from "@mat3ra/cove.js/dist/utils/downloader";
+import { AlertProvider } from "@mat3ra/cove.js/src/theme/provider";
 import { Made } from "@mat3ra/made";
 import Article from "@mui/icons-material/Article";
 import Autorenew from "@mui/icons-material/Autorenew";

--- a/src/components/ThreeDEditor.jsx
+++ b/src/components/ThreeDEditor.jsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/sort-comp */
 // import "../MuiClassNameSetup";
 
-import { DarkMaterialUITheme } from "@mat3ra/cove.js/dist/theme";
-import ThemeProvider from "@mat3ra/cove.js/dist/theme/provider";
-import { exportToDisk } from "@mat3ra/cove.js/dist/utils/downloader";
-import { AlertProvider } from "@mat3ra/cove.js/src/theme/provider";
+import { DarkMaterialUITheme } from "@mat3ra/cove/dist/theme";
+import ThemeProvider from "@mat3ra/cove/dist/theme/provider";
+import { exportToDisk } from "@mat3ra/cove/dist/utils/downloader";
+import { AlertProvider } from "@mat3ra/cove/src/theme/provider";
 import { Made } from "@mat3ra/made";
 import Article from "@mui/icons-material/Article";
 import Autorenew from "@mui/icons-material/Autorenew";

--- a/src/mixins/image.js
+++ b/src/mixins/image.js
@@ -1,9 +1,5 @@
-import {
-    showInfoAlert,
-    showSuccessAlert,
-    showWarningAlert,
-} from "@mat3ra/cove.js/dist/other/alerts";
-import { saveImageDataToFile } from "@mat3ra/cove.js/dist/utils/downloader";
+import { showInfoAlert, showSuccessAlert, showWarningAlert } from "@mat3ra/cove/dist/other/alerts";
+import { saveImageDataToFile } from "@mat3ra/cove/dist/utils/downloader";
 
 import { createGIFAsync } from "./utils";
 

--- a/src/mixins/image.js
+++ b/src/mixins/image.js
@@ -2,8 +2,8 @@ import {
     showInfoAlert,
     showSuccessAlert,
     showWarningAlert,
-} from "@exabyte-io/cove.js/dist/other/alerts";
-import { saveImageDataToFile } from "@exabyte-io/cove.js/dist/utils/downloader";
+} from "@mat3ra/cove.js/dist/other/alerts";
+import { saveImageDataToFile } from "@mat3ra/cove.js/dist/utils/downloader";
 
 import { createGIFAsync } from "./utils";
 


### PR DESCRIPTION
`@exabyte-io/cove.js` was renamed to `@mat3ra/cove.js` (mat3ra/cove.js#91, first release `2026.7.18-1`). Switches the dependency and every import path (src + committed dist — a pure module-path rename) and regenerates the lockfile. Part of the org-wide cove scope migration (pilot verified with full install + tests in mat3ra/move#3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)