### PR TITLE
chore: migrate package to @mat3ra scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm version](https://badge.fury.io/js/%40exabyte-io%2Fwave.js.svg)](https://badge.fury.io/js/%40exabyte-io%2Fwave.js)
+[![npm version](https://badge.fury.io/js/%40mat3ra%2Fwave.js.svg)](https://badge.fury.io/js/%40mat3ra%2Fwave.js)
 [![License: Apache](https://img.shields.io/badge/License-Apache-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 # Wave.js
@@ -31,14 +31,14 @@ The package is written in a modular way easy to extend. Contributions can be in 
 From NPM for use within a software project:
 
 ```bash
-npm install @exabyte-io/wave.js
+npm install @mat3ra/wave.js
 
 ```
 
 From source to contribute to development:
 
 ```bash
-git clone git@github.com:Exabyte-io/wave.git
+git clone git@github.com:mat3ra/wave.js.git
 ```
 
 ## 3. Contribution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@exabyte-io/wave.js",
+    "name": "@mat3ra/wave.js",
     "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@exabyte-io/wave.js",
+            "name": "@mat3ra/wave.js",
             "version": "0.0.0",
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@exabyte-io/wave.js",
+    "name": "@mat3ra/wave.js",
     "version": "0.0.0",
     "description": "Web-based Atomic Viewer and Editor in JavaScript.",
     "scripts": {
@@ -15,7 +15,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/Exabyte-io/wave.js.git"
+        "url": "https://github.com/mat3ra/wave.js.git"
     },
     "main": "dist/exports.js",
     "files": [
@@ -25,10 +25,10 @@
     ],
     "author": "Exabyte Inc.",
     "bugs": {
-        "url": "https://github.com/Exabyte-io/wave/issues"
+        "url": "https://github.com/mat3ra/wave.js/issues"
     },
     "license": "Apache-2.0",
-    "homepage": ".",
+    "homepage": "https://github.com/mat3ra/wave.js",
     "dependencies": {
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",


### PR DESCRIPTION
Renames the npm package `@exabyte-io/wave.js` → `@mat3ra/wave.js` (name, repository/bugs/homepage URLs, README, lockfile) to match where the repo already lives (github.com/mat3ra/wave.js). Same pattern as the cove.js scope migration (mat3ra/cove.js#91).

Also fixes two pre-existing README bugs while touching these lines: the git-clone command was missing `.js` and pointed at the wrong org (`Exabyte-io/wave` instead of `mat3ra/wave.js`); the npm badge/install line said `@exabyte-io`.

On merge, CI publishes the first `@mat3ra/wave.js` release. Existing `@exabyte-io/wave.js` versions stay on npm for older branches; consumers (materials-designer, web-app, and any other repo pinning wave.js) migrate in follow-up PRs.

Verified locally: `npm run transpile` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)