### PR TITLE
feat: implement onEditCommit host callback (spec §6.2)

### DIFF
--- a/dist/components/ThreeDEditor.d.ts
+++ b/dist/components/ThreeDEditor.d.ts
@@ -61,7 +61,7 @@ export class ThreeDEditor extends React.Component<any, any, any> {
     handleToggleOrbitControls(): void;
     handleToggleOrbitControlsAnimation(): void;
     handleToggleAxes(): void;
-    handleStructureModified(newMaterial: any): void;
+    handleStructureModified(newMaterial: any, source: any): void;
     handleUndo(): void;
     handleRedo(): void;
     /**
@@ -176,9 +176,12 @@ export class ThreeDEditor extends React.Component<any, any, any> {
      * Pushes a material to the viewer via the official setStructure()/rebuildScene() path and
      * notifies the parent. Used as the setState callback for every history-affecting change
      * (edit, undo, redo) once bypassReloadViewer has already been set so WaveComponent's own
-     * prop-driven reload doesn't race with it.
+     * prop-driven reload doesn't race with it. `source` is spec Sec6.2's onEditCommit contract
+     * (`drag`/`gizmo`/`coordinate-input`/`element-input`/`add`/`remove`/`clone`/`undo`/`redo`) -
+     * forwarded alongside the back-compat `onUpdate` channel so a host can record history without
+     * double-counting instead of having to re-infer what kind of edit just happened.
      */
-    _applyMaterialToViewer(material: any): void;
+    _applyMaterialToViewer(material: any, source: any): void;
     _getWaveProperty(name: any): any;
     /**
      * Returns a cover div to cover the area and prevent user interaction with component
@@ -345,6 +348,7 @@ export namespace ThreeDEditor {
         let isConventionalCellShown: PropTypes.Requireable<boolean>;
         let boundaryConditions: PropTypes.Requireable<object>;
         let onUpdate: PropTypes.Requireable<(...args: any[]) => any>;
+        let onEditCommit: PropTypes.Requireable<(...args: any[]) => any>;
         let onEditModeChanged: PropTypes.Requireable<(...args: any[]) => any>;
         let onSelectionChanged: PropTypes.Requireable<(...args: any[]) => any>;
         let isStandalone: PropTypes.Requireable<boolean>;
@@ -358,6 +362,8 @@ export namespace ThreeDEditor {
         export { isConventionalCellShown_1 as isConventionalCellShown };
         let onUpdate_1: undefined;
         export { onUpdate_1 as onUpdate };
+        let onEditCommit_1: undefined;
+        export { onEditCommit_1 as onEditCommit };
         let onEditModeChanged_1: undefined;
         export { onEditModeChanged_1 as onEditModeChanged };
         let onSelectionChanged_1: undefined;

--- a/dist/components/ThreeDEditor.js
+++ b/dist/components/ThreeDEditor.js
@@ -604,10 +604,13 @@ export class ThreeDEditor extends React.Component {
      * Pushes a material to the viewer via the official setStructure()/rebuildScene() path and
      * notifies the parent. Used as the setState callback for every history-affecting change
      * (edit, undo, redo) once bypassReloadViewer has already been set so WaveComponent's own
-     * prop-driven reload doesn't race with it.
+     * prop-driven reload doesn't race with it. `source` is spec Sec6.2's onEditCommit contract
+     * (`drag`/`gizmo`/`coordinate-input`/`element-input`/`add`/`remove`/`clone`/`undo`/`redo`) -
+     * forwarded alongside the back-compat `onUpdate` channel so a host can record history without
+     * double-counting instead of having to re-infer what kind of edit just happened.
      */
-    _applyMaterialToViewer(material) {
-        const { onUpdate } = this.props;
+    _applyMaterialToViewer(material, source) {
+        const { onUpdate, onEditCommit } = this.props;
         if (this.WaveComponent && this.WaveComponent.wave) {
             this.WaveComponent.wave.bypassReloadViewer = false;
             this.WaveComponent.wave.setStructure(material);
@@ -616,8 +619,11 @@ export class ThreeDEditor extends React.Component {
         if (onUpdate) {
             onUpdate(material);
         }
+        if (onEditCommit) {
+            onEditCommit(material, { source });
+        }
     }
-    handleStructureModified(newMaterial) {
+    handleStructureModified(newMaterial, source) {
         const { material, historyStack, historyPointer } = this.state;
         if (this.WaveComponent && this.WaveComponent.wave) {
             this.WaveComponent.wave.bypassReloadViewer = true;
@@ -633,7 +639,7 @@ export class ThreeDEditor extends React.Component {
             material: clonedMaterial,
             historyStack: newStack,
             historyPointer: newStack.length - 1,
-        }, () => this._applyMaterialToViewer(clonedMaterial));
+        }, () => this._applyMaterialToViewer(clonedMaterial, source));
     }
     handleUndo() {
         const { historyStack, historyPointer } = this.state;
@@ -647,7 +653,7 @@ export class ThreeDEditor extends React.Component {
         this.setState({
             material: previousMaterial,
             historyPointer: previousPointer,
-        }, () => this._applyMaterialToViewer(previousMaterial));
+        }, () => this._applyMaterialToViewer(previousMaterial, "undo"));
     }
     handleRedo() {
         const { historyStack, historyPointer } = this.state;
@@ -661,7 +667,7 @@ export class ThreeDEditor extends React.Component {
         this.setState({
             material: nextMaterial,
             historyPointer: nextPointer,
-        }, () => this._applyMaterialToViewer(nextMaterial));
+        }, () => this._applyMaterialToViewer(nextMaterial, "redo"));
     }
     /**
      * Public, ref-accessible undo-availability check (part of the host embedding API - a host
@@ -723,7 +729,7 @@ export class ThreeDEditor extends React.Component {
             this.WaveComponent.wave.selectedMesh_.position.setComponent(axisIndex, floatValue);
             this.WaveComponent.wave.render();
         }
-        this.handleStructureModified(newMaterial);
+        this.handleStructureModified(newMaterial, "coordinate-input");
     }
     /**
      * Updates only the local draft string for one coordinate field while it's focused - no
@@ -894,7 +900,7 @@ export class ThreeDEditor extends React.Component {
                     };
                     newBasis.elements = newElements;
                     newMaterial.setBasis(newBasis.toJSON());
-                    this.handleStructureModified(newMaterial);
+                    this.handleStructureModified(newMaterial, "element-input");
                 }
             }
         }
@@ -1131,6 +1137,11 @@ ThreeDEditor.propTypes = {
     isConventionalCellShown: PropTypes.bool, // eslint-disable-next-line react/forbid-prop-types
     boundaryConditions: PropTypes.object,
     onUpdate: PropTypes.func,
+    // Fires once per committed edit, like onUpdate, but also carries {source} - one of "drag",
+    // "gizmo", "coordinate-input", "element-input", "add", "remove", "clone", "undo", "redo" - so
+    // a host can record its own history without double-counting onUpdate's every-edit cadence
+    // against its own undo/redo actions (spec §6.2).
+    onEditCommit: PropTypes.func,
     // Fires whenever edit mode is toggled on/off, so a host can disable conflicting UI.
     onEditModeChanged: PropTypes.func,
     // Fires with the current array of selected atomicIndex whenever the selection changes
@@ -1147,6 +1158,7 @@ ThreeDEditor.defaultProps = {
     boundaryConditions: {},
     isConventionalCellShown: false,
     onUpdate: undefined,
+    onEditCommit: undefined,
     onEditModeChanged: undefined,
     onSelectionChanged: undefined,
     editable: false,

--- a/dist/mixins/interactive_structure_editor.d.ts
+++ b/dist/mixins/interactive_structure_editor.d.ts
@@ -305,15 +305,18 @@ export declare const InteractiveStructureEditorMixin: (superclass: any) => {
          * itself preserves the selection/gizmo across the rebuild when in edit mode (see
          * wave.js), so no explicit reselect is needed here for the move case.
          */
-        commitMovedAtom_(atomicIndex: number, cartesianPosition: THREE.Vector3): void;
+        commitMovedAtom_(atomicIndex: number, cartesianPosition: THREE.Vector3, source: string): void;
         /**
          * Commits any number of moved atoms as a single delta/commit (one history entry) applied
-         * to the current material, then rebuilds the scene around it.
+         * to the current material, then rebuilds the scene around it. `source` (spec Sec6.2's
+         * onEditCommit contract - "drag" for a direct body-drag, "gizmo" for a TransformControls
+         * drag) is forwarded to onStructureModified so ThreeDEditor.jsx can pass it on to a host's
+         * onEditCommit without having to re-infer which gesture produced this commit.
          */
         commitMovedAtoms_(moves: Array<{
             atomicIndex: number;
             position: THREE.Vector3;
-        }>): void;
+        }>, source: string): void;
         /**
          * Lifecycle hook to dispose event listeners and objects on visualizer destruction.
          */

--- a/dist/mixins/interactive_structure_editor.js
+++ b/dist/mixins/interactive_structure_editor.js
@@ -165,7 +165,7 @@ export const InteractiveStructureEditorMixin = (superclass) => class extends sup
                     this.commitMovedAtoms_(this.selectedMeshes_.map((mesh) => ({
                         atomicIndex: mesh.userData.atomicIndex,
                         position: mesh.position.clone(),
-                    })));
+                    })), "gizmo");
                     if (wasRotate) {
                         // The pivot's rotation is relative to each drag, not cumulative
                         // across drags - the atoms' new positions already encode the
@@ -174,7 +174,7 @@ export const InteractiveStructureEditorMixin = (superclass) => class extends sup
                     }
                 }
                 else {
-                    this.commitMovedAtom_(draggedObject.userData.atomicIndex, draggedObject.position);
+                    this.commitMovedAtom_(draggedObject.userData.atomicIndex, draggedObject.position, "gizmo");
                 }
             }
             this.groupDragStartPositions_ = null;
@@ -598,10 +598,10 @@ export const InteractiveStructureEditorMixin = (superclass) => class extends sup
             this.commitMovedAtoms_(groupMeshes.map((mesh) => ({
                 atomicIndex: mesh.userData.atomicIndex,
                 position: mesh.position.clone(),
-            })));
+            })), "drag");
         }
         else if (atom) {
-            this.commitMovedAtom_(atom.userData.atomicIndex, atom.position);
+            this.commitMovedAtom_(atom.userData.atomicIndex, atom.position, "drag");
         }
     }
     /**
@@ -1008,7 +1008,7 @@ export const InteractiveStructureEditorMixin = (superclass) => class extends sup
         // from whatever was selected before Add Atom ran).
         this.reselectAtomByIndex(newIndex);
         if (this.settings.onStructureModified) {
-            this.settings.onStructureModified(newMaterial);
+            this.settings.onStructureModified(newMaterial, "add");
         }
     }
     /**
@@ -1044,7 +1044,7 @@ export const InteractiveStructureEditorMixin = (superclass) => class extends sup
         this.structureGroup.name = newMaterial.name || newMaterial.formula;
         this.rebuildScene();
         if (this.settings.onStructureModified) {
-            this.settings.onStructureModified(newMaterial);
+            this.settings.onStructureModified(newMaterial, "remove");
         }
     }
     /**
@@ -1076,7 +1076,7 @@ export const InteractiveStructureEditorMixin = (superclass) => class extends sup
         this.structureGroup.name = newMaterial.name || newMaterial.formula;
         this.rebuildScene();
         if (this.settings.onStructureModified) {
-            this.settings.onStructureModified(newMaterial);
+            this.settings.onStructureModified(newMaterial, "remove");
         }
     }
     /**
@@ -1138,7 +1138,7 @@ export const InteractiveStructureEditorMixin = (superclass) => class extends sup
         // from whatever was selected going in).
         this.reselectAtomsByIndices(newIndices);
         if (this.settings.onStructureModified) {
-            this.settings.onStructureModified(newMaterial);
+            this.settings.onStructureModified(newMaterial, "clone");
         }
     }
     /**
@@ -1182,14 +1182,17 @@ export const InteractiveStructureEditorMixin = (superclass) => class extends sup
      * itself preserves the selection/gizmo across the rebuild when in edit mode (see
      * wave.js), so no explicit reselect is needed here for the move case.
      */
-    commitMovedAtom_(atomicIndex, cartesianPosition) {
-        this.commitMovedAtoms_([{ atomicIndex, position: cartesianPosition }]);
+    commitMovedAtom_(atomicIndex, cartesianPosition, source) {
+        this.commitMovedAtoms_([{ atomicIndex, position: cartesianPosition }], source);
     }
     /**
      * Commits any number of moved atoms as a single delta/commit (one history entry) applied
-     * to the current material, then rebuilds the scene around it.
+     * to the current material, then rebuilds the scene around it. `source` (spec Sec6.2's
+     * onEditCommit contract - "drag" for a direct body-drag, "gizmo" for a TransformControls
+     * drag) is forwarded to onStructureModified so ThreeDEditor.jsx can pass it on to a host's
+     * onEditCommit without having to re-infer which gesture produced this commit.
      */
-    commitMovedAtoms_(moves) {
+    commitMovedAtoms_(moves, source) {
         if (!moves.length)
             return;
         const newMaterial = this.applyBasisDelta_((basis) => {
@@ -1211,7 +1214,7 @@ export const InteractiveStructureEditorMixin = (superclass) => class extends sup
         this.setStructure(newMaterial);
         this.rebuildScene();
         if (this.settings.onStructureModified) {
-            this.settings.onStructureModified(newMaterial);
+            this.settings.onStructureModified(newMaterial, source);
         }
     }
     /**

--- a/docs/design/interactive-editor-spec.md
+++ b/docs/design/interactive-editor-spec.md
@@ -300,7 +300,7 @@ Diagram: **[data-flow.svg](./assets/data-flow.svg)**. The old modal contract (`m
 | Callback | Cadence | Purpose |
 |---|---|---|
 | `onUpdate(material′)` | Once per committed edit | Back-compat channel (existing MD wiring) |
-| `onEditCommit(material′, {source})` | Once per committed edit | `source ∈ drag · gizmo · coordinate-input · add · remove · undo · redo` — lets hosts record history without double-counting |
+| `onEditCommit(material′, {source})` | Once per committed edit | **Shipped 2026-08-01.** `source ∈ drag · gizmo · coordinate-input · element-input · add · remove · clone · undo · redo` (`element-input` and `clone` added to the original 7-value enum for this round's type-to-change and clone-atom features) — lets hosts record history without double-counting |
 | `onSelectionChanged(atomicIndices)` | On selection change | Promoted to a public prop (MD's selection footer needs it — gap #6). **Signature updated 2026-07-14 for D-4 (multi-select): reports an array, not a single index-or-null** — `[]` for none, one entry for the common single-atom case, 2+ for a group. This is a breaking change from the single-index contract this section originally specified; no external consumer existed yet (materials-designer is pinned to the pre-P0 export, unaffected) |
 | `onEditModeChanged(isActive)` | On toggle | Hosts disable conflicting UI |
 | `onEditSessionStart(material)` / `onEditSessionEnd(finalOrNull)` | Session bounds | Optional transactional layer (decision D-3): `null` = cancelled; restores the modal's commit-or-discard guarantee |

--- a/src/components/ThreeDEditor.jsx
+++ b/src/components/ThreeDEditor.jsx
@@ -471,10 +471,13 @@ export class ThreeDEditor extends React.Component {
      * Pushes a material to the viewer via the official setStructure()/rebuildScene() path and
      * notifies the parent. Used as the setState callback for every history-affecting change
      * (edit, undo, redo) once bypassReloadViewer has already been set so WaveComponent's own
-     * prop-driven reload doesn't race with it.
+     * prop-driven reload doesn't race with it. `source` is spec Sec6.2's onEditCommit contract
+     * (`drag`/`gizmo`/`coordinate-input`/`element-input`/`add`/`remove`/`clone`/`undo`/`redo`) -
+     * forwarded alongside the back-compat `onUpdate` channel so a host can record history without
+     * double-counting instead of having to re-infer what kind of edit just happened.
      */
-    _applyMaterialToViewer(material) {
-        const { onUpdate } = this.props;
+    _applyMaterialToViewer(material, source) {
+        const { onUpdate, onEditCommit } = this.props;
         if (this.WaveComponent && this.WaveComponent.wave) {
             this.WaveComponent.wave.bypassReloadViewer = false;
             this.WaveComponent.wave.setStructure(material);
@@ -483,9 +486,12 @@ export class ThreeDEditor extends React.Component {
         if (onUpdate) {
             onUpdate(material);
         }
+        if (onEditCommit) {
+            onEditCommit(material, { source });
+        }
     }
 
-    handleStructureModified(newMaterial) {
+    handleStructureModified(newMaterial, source) {
         const { material, historyStack, historyPointer } = this.state;
         if (this.WaveComponent && this.WaveComponent.wave) {
             this.WaveComponent.wave.bypassReloadViewer = true;
@@ -506,7 +512,7 @@ export class ThreeDEditor extends React.Component {
                 historyStack: newStack,
                 historyPointer: newStack.length - 1,
             },
-            () => this._applyMaterialToViewer(clonedMaterial),
+            () => this._applyMaterialToViewer(clonedMaterial, source),
         );
     }
 
@@ -525,7 +531,7 @@ export class ThreeDEditor extends React.Component {
                 material: previousMaterial,
                 historyPointer: previousPointer,
             },
-            () => this._applyMaterialToViewer(previousMaterial),
+            () => this._applyMaterialToViewer(previousMaterial, "undo"),
         );
     }
 
@@ -544,7 +550,7 @@ export class ThreeDEditor extends React.Component {
                 material: nextMaterial,
                 historyPointer: nextPointer,
             },
-            () => this._applyMaterialToViewer(nextMaterial),
+            () => this._applyMaterialToViewer(nextMaterial, "redo"),
         );
     }
 
@@ -613,7 +619,7 @@ export class ThreeDEditor extends React.Component {
             this.WaveComponent.wave.render();
         }
 
-        this.handleStructureModified(newMaterial);
+        this.handleStructureModified(newMaterial, "coordinate-input");
     }
 
     /**
@@ -807,7 +813,7 @@ export class ThreeDEditor extends React.Component {
                     };
                     newBasis.elements = newElements;
                     newMaterial.setBasis(newBasis.toJSON());
-                    this.handleStructureModified(newMaterial);
+                    this.handleStructureModified(newMaterial, "element-input");
                 }
             }
         }
@@ -1481,6 +1487,11 @@ ThreeDEditor.propTypes = {
     isConventionalCellShown: PropTypes.bool, // eslint-disable-next-line react/forbid-prop-types
     boundaryConditions: PropTypes.object,
     onUpdate: PropTypes.func,
+    // Fires once per committed edit, like onUpdate, but also carries {source} - one of "drag",
+    // "gizmo", "coordinate-input", "element-input", "add", "remove", "clone", "undo", "redo" - so
+    // a host can record its own history without double-counting onUpdate's every-edit cadence
+    // against its own undo/redo actions (spec §6.2).
+    onEditCommit: PropTypes.func,
     // Fires whenever edit mode is toggled on/off, so a host can disable conflicting UI.
     onEditModeChanged: PropTypes.func,
     // Fires with the current array of selected atomicIndex whenever the selection changes
@@ -1498,6 +1509,7 @@ ThreeDEditor.defaultProps = {
     boundaryConditions: {},
     isConventionalCellShown: false,
     onUpdate: undefined,
+    onEditCommit: undefined,
     onEditModeChanged: undefined,
     onSelectionChanged: undefined,
     editable: false,

--- a/src/mixins/interactive_structure_editor.ts
+++ b/src/mixins/interactive_structure_editor.ts
@@ -246,6 +246,7 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
                                 atomicIndex: mesh.userData.atomicIndex,
                                 position: mesh.position.clone(),
                             })),
+                            "gizmo",
                         );
                         if (wasRotate) {
                             // The pivot's rotation is relative to each drag, not cumulative
@@ -257,6 +258,7 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
                         this.commitMovedAtom_(
                             draggedObject.userData.atomicIndex,
                             draggedObject.position,
+                            "gizmo",
                         );
                     }
                 }
@@ -728,9 +730,10 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
                         atomicIndex: mesh.userData.atomicIndex,
                         position: mesh.position.clone(),
                     })),
+                    "drag",
                 );
             } else if (atom) {
-                this.commitMovedAtom_(atom.userData.atomicIndex, atom.position);
+                this.commitMovedAtom_(atom.userData.atomicIndex, atom.position, "drag");
             }
         }
 
@@ -1151,7 +1154,7 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
             this.reselectAtomByIndex(newIndex);
 
             if (this.settings.onStructureModified) {
-                this.settings.onStructureModified(newMaterial);
+                this.settings.onStructureModified(newMaterial, "add");
             }
         }
 
@@ -1196,7 +1199,7 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
             this.rebuildScene();
 
             if (this.settings.onStructureModified) {
-                this.settings.onStructureModified(newMaterial);
+                this.settings.onStructureModified(newMaterial, "remove");
             }
         }
 
@@ -1241,7 +1244,7 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
             this.rebuildScene();
 
             if (this.settings.onStructureModified) {
-                this.settings.onStructureModified(newMaterial);
+                this.settings.onStructureModified(newMaterial, "remove");
             }
         }
 
@@ -1310,7 +1313,7 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
             // from whatever was selected going in).
             this.reselectAtomsByIndices(newIndices);
             if (this.settings.onStructureModified) {
-                this.settings.onStructureModified(newMaterial);
+                this.settings.onStructureModified(newMaterial, "clone");
             }
         }
 
@@ -1363,15 +1366,25 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
          * itself preserves the selection/gizmo across the rebuild when in edit mode (see
          * wave.js), so no explicit reselect is needed here for the move case.
          */
-        commitMovedAtom_(atomicIndex: number, cartesianPosition: THREE.Vector3): void {
-            this.commitMovedAtoms_([{ atomicIndex, position: cartesianPosition }]);
+        commitMovedAtom_(
+            atomicIndex: number,
+            cartesianPosition: THREE.Vector3,
+            source: string,
+        ): void {
+            this.commitMovedAtoms_([{ atomicIndex, position: cartesianPosition }], source);
         }
 
         /**
          * Commits any number of moved atoms as a single delta/commit (one history entry) applied
-         * to the current material, then rebuilds the scene around it.
+         * to the current material, then rebuilds the scene around it. `source` (spec Sec6.2's
+         * onEditCommit contract - "drag" for a direct body-drag, "gizmo" for a TransformControls
+         * drag) is forwarded to onStructureModified so ThreeDEditor.jsx can pass it on to a host's
+         * onEditCommit without having to re-infer which gesture produced this commit.
          */
-        commitMovedAtoms_(moves: Array<{ atomicIndex: number; position: THREE.Vector3 }>): void {
+        commitMovedAtoms_(
+            moves: Array<{ atomicIndex: number; position: THREE.Vector3 }>,
+            source: string,
+        ): void {
             if (!moves.length) return;
             const newMaterial = this.applyBasisDelta_((basis: any) => {
                 const wasCartesian = basis.isInCartesianUnits;
@@ -1392,7 +1405,7 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
             this.rebuildScene();
 
             if (this.settings.onStructureModified) {
-                this.settings.onStructureModified(newMaterial);
+                this.settings.onStructureModified(newMaterial, source);
             }
         }
 

--- a/tests/__tests__/components/ThreeDEditor.jsx
+++ b/tests/__tests__/components/ThreeDEditor.jsx
@@ -912,3 +912,81 @@ describe("TB-persona review fixes (PR #204 round 1-2)", () => {
         expect(onSelectionChanged).toHaveBeenLastCalledWith([]);
     });
 });
+
+describe("onEditCommit host callback (spec §6.2)", () => {
+    function mountWithOnEditCommit() {
+        const onEditCommit = jest.fn();
+        const container = createElement("div", ELEMENT_PROPERTIES);
+        const wrapper = mount(
+            <ThreeDEditor
+                material={new Made.Material(MATERIAL_CONFIG)}
+                editable
+                onEditCommit={onEditCommit}
+            />,
+            { attachTo: container },
+        );
+        return { wrapper, onEditCommit };
+    }
+
+    test("Fires alongside onUpdate, with {source: 'coordinate-input'}, for a typed coordinate edit", () => {
+        const { wrapper, onEditCommit } = mountWithOnEditCommit();
+        const instance = wrapper.instance();
+
+        instance.handleSelectionChanged([1]);
+        instance.handleCoordinateDraftChange(0, "0.42");
+        instance.handleCoordinateCommit(0);
+
+        expect(onEditCommit).toHaveBeenCalledTimes(1);
+        const [material, meta] = onEditCommit.mock.calls[0];
+        expect(material).toBe(wrapper.state("material"));
+        expect(meta).toEqual({ source: "coordinate-input" });
+    });
+
+    test("Fires with {source: 'element-input'} for a typed element rename", () => {
+        const { wrapper, onEditCommit } = mountWithOnEditCommit();
+        const instance = wrapper.instance();
+
+        instance.handleSelectionChanged([0]);
+        instance.handleElementDraftChange("fe");
+        instance.handleElementCommit();
+
+        expect(onEditCommit).toHaveBeenCalledTimes(1);
+        const [, meta] = onEditCommit.mock.calls[0];
+        expect(meta).toEqual({ source: "element-input" });
+    });
+
+    test("Fires with {source: 'add'} for Add Atom, forwarded from the mixin's own source tag", () => {
+        const { wrapper, onEditCommit } = mountWithOnEditCommit();
+        wrapper.instance().handleAddAtom();
+
+        expect(onEditCommit).toHaveBeenCalledTimes(1);
+        const [, meta] = onEditCommit.mock.calls[0];
+        expect(meta).toEqual({ source: "add" });
+    });
+
+    test("Fires with {source: 'undo'} / {source: 'redo'} for undo/redo, distinct from the edit's own source", () => {
+        const { wrapper, onEditCommit } = mountWithOnEditCommit();
+        const instance = wrapper.instance();
+
+        instance.handleAddAtom();
+        expect(onEditCommit).toHaveBeenLastCalledWith(expect.anything(), { source: "add" });
+
+        instance.handleUndo();
+        expect(onEditCommit).toHaveBeenLastCalledWith(expect.anything(), { source: "undo" });
+
+        instance.handleRedo();
+        expect(onEditCommit).toHaveBeenLastCalledWith(expect.anything(), { source: "redo" });
+
+        expect(onEditCommit).toHaveBeenCalledTimes(3);
+    });
+
+    test("Is not required - omitting the prop does not throw on commit", () => {
+        const container = createElement("div", ELEMENT_PROPERTIES);
+        const wrapper = mount(
+            <ThreeDEditor material={new Made.Material(MATERIAL_CONFIG)} editable />,
+            { attachTo: container },
+        );
+
+        expect(() => wrapper.instance().handleAddAtom()).not.toThrow();
+    });
+});

--- a/tests/__tests__/mixins/interactive_structure_editor.js
+++ b/tests/__tests__/mixins/interactive_structure_editor.js
@@ -1147,4 +1147,102 @@ describe("Interactive structure editor functionality tests", () => {
             expect(structureModifiedCalls.length).toBe(0);
         });
     });
+
+    describe("onEditCommit source tagging (spec §6.2)", () => {
+        // onStructureModified(material, source) is the mixin-level half of spec §6.2's
+        // onEditCommit(material, {source}) contract - ThreeDEditor.jsx forwards this second
+        // argument as-is. Verifying it at this layer (rather than only end-to-end through the
+        // component) pins down exactly which mixin method is responsible for which source value,
+        // independent of the React-side plumbing.
+        test("A direct body-drag commits with source 'drag'", () => {
+            const { wave, structureModifiedCalls } = getWaveWithRecordedCallbacks();
+            wave.enableEditMode(true);
+            stubCanvasRect(wave);
+
+            const [firstAtom] = wave.collectSelectableAtoms();
+            simulateAtomDrag(wave, firstAtom, 40, 30);
+
+            expect(structureModifiedCalls.length).toBe(1);
+            const [, source] = structureModifiedCalls[0];
+            expect(source).toBe("drag");
+        });
+
+        test("A group gizmo commit (translate or rotate) commits with source 'gizmo'", () => {
+            const { wave, structureModifiedCalls } = getWaveWithRecordedCallbacks();
+            wave.enableEditMode(true);
+
+            const atoms = wave.collectSelectableAtoms();
+            wave.setSelectedAtomMeshes(atoms);
+
+            wave.transformControls_.dragging = true;
+            wave.selectionPivot_.position.x += 1;
+            wave.transformControls_.dispatchEvent({ type: "change" });
+            wave.transformControls_.dispatchEvent({ type: "mouseUp" });
+            wave.transformControls_.dragging = false;
+
+            expect(structureModifiedCalls.length).toBe(1);
+            const [, source] = structureModifiedCalls[0];
+            expect(source).toBe("gizmo");
+        });
+
+        test("A single-atom gizmo commit also commits with source 'gizmo'", () => {
+            const { wave, structureModifiedCalls } = getWaveWithRecordedCallbacks();
+            wave.enableEditMode(true);
+            const [firstAtom] = wave.collectSelectableAtoms();
+            wave.setSelectedAtomMesh(firstAtom);
+
+            wave.transformControls_.dragging = true;
+            firstAtom.position.x += 1;
+            wave.transformControls_.dispatchEvent({ type: "change" });
+            wave.transformControls_.dispatchEvent({ type: "mouseUp" });
+            wave.transformControls_.dragging = false;
+
+            expect(structureModifiedCalls.length).toBe(1);
+            const [, source] = structureModifiedCalls[0];
+            expect(source).toBe("gizmo");
+        });
+
+        test("Add Atom commits with source 'add'", () => {
+            const { wave, structureModifiedCalls } = getWaveWithRecordedCallbacks();
+            wave.addAtom("Si", [0, 0, 0]);
+
+            expect(structureModifiedCalls.length).toBe(1);
+            const [, source] = structureModifiedCalls[0];
+            expect(source).toBe("add");
+        });
+
+        test("Removing a single atom commits with source 'remove'", () => {
+            const { wave, structureModifiedCalls } = getWaveWithRecordedCallbacks();
+            const [firstAtom] = wave.collectSelectableAtoms();
+            wave.selectedMesh_ = firstAtom;
+            wave.removeSelectedAtom();
+
+            expect(structureModifiedCalls.length).toBe(1);
+            const [, source] = structureModifiedCalls[0];
+            expect(source).toBe("remove");
+        });
+
+        test("Removing a multi-selection commits with source 'remove'", () => {
+            const { wave, structureModifiedCalls } = getWaveWithRecordedCallbacks();
+            wave.enableEditMode(true);
+            const atoms = wave.collectSelectableAtoms();
+            wave.setSelectedAtomMeshes(atoms);
+            wave.removeSelectedAtom();
+
+            expect(structureModifiedCalls.length).toBe(1);
+            const [, source] = structureModifiedCalls[0];
+            expect(source).toBe("remove");
+        });
+
+        test("Cloning commits with source 'clone'", () => {
+            const { wave, structureModifiedCalls } = getWaveWithRecordedCallbacks();
+            const [firstAtom] = wave.collectSelectableAtoms();
+            wave.setSelectedAtomMeshes([firstAtom]);
+            wave.cloneSelectedAtoms();
+
+            expect(structureModifiedCalls.length).toBe(1);
+            const [, source] = structureModifiedCalls[0];
+            expect(source).toBe("clone");
+        });
+    });
 });

--- a/tests/helpers/editor.js
+++ b/tests/helpers/editor.js
@@ -169,10 +169,10 @@ export function simulateAtomDrag(
     // or a plain settings.onStructureModified); the original callback (if any) still fires.
     let modifiedMaterial = null;
     const originalOnStructureModified = wave.settings.onStructureModified;
-    wave.settings.onStructureModified = (material) => {
+    wave.settings.onStructureModified = (material, ...rest) => {
         modifiedMaterial = material;
-        if (onStructureModified) onStructureModified(material);
-        if (originalOnStructureModified) originalOnStructureModified(material);
+        if (onStructureModified) onStructureModified(material, ...rest);
+        if (originalOnStructureModified) originalOnStructureModified(material, ...rest);
     };
 
     try {


### PR DESCRIPTION
## Summary

Completes a host-API gap the TB-persona review of #204 flagged: `onEditCommit` was listed in `docs/design/interactive-editor-spec.md` §6.2 (P1 scope, alongside `onSelectionChanged`/`onEditModeChanged`) but never actually implemented — only `onUpdate`'s every-edit, source-agnostic channel existed. That's exactly the flood that broke materials-designer's redux history integration with the old modal editor in the first place.

- Threads a `source` string through every commit path down to `onStructureModified(material, source)` in the mixin: `"drag"` (direct body-drag) vs `"gizmo"` (TransformControls-driven, translate or rotate alike), `"add"`, `"remove"`, `"clone"`.
- `ThreeDEditor.jsx` forwards this to a new `onEditCommit(material, {source})` prop, and adds `"coordinate-input"`/`"element-input"` for its own typed-panel edits and `"undo"`/`"redo"` for `handleUndo`/`handleRedo` (which bypass the shared commit path entirely).
- Extends the spec's original 7-value `source` enum with `"element-input"` and `"clone"`, since those two features postdate when §6.2 was written.
- Fixes a latent bug in `tests/helpers/editor.js`'s `simulateAtomDrag`: its `onStructureModified` interceptor only forwarded the first (`material`) argument, silently dropping `source` — would have masked this working correctly for the direct-drag path specifically.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean (pre-existing `any` warnings only)
- [x] Full Jest suite green (175/177, 2 pre-existing skips) — 12 new tests covering every `source` value at both the mixin level (`onStructureModified`'s second argument) and the component level (`onEditCommit`'s `{source}` shape), plus one confirming the prop is optional
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)