### PR TITLE
docs: resolve D-2 - multi-material merge stays out of wave.js

### DIFF
--- a/docs/design/interactive-editor-spec.md
+++ b/docs/design/interactive-editor-spec.md
@@ -294,7 +294,7 @@ Diagram: **[data-flow.svg](./assets/data-flow.svg)**. The old modal contract (`m
 
 | Prop | Type | Notes |
 |---|---|---|
-| `material` | `Made.Material` (required) | Singular. Multi-material: decision D-2 |
+| `material` | `Made.Material` (required) | Singular, permanently — multi-material merge stays out of this component's contract (decision D-2, §9) |
 | `editable` | `bool` | Shows the Edit toggle |
 | `editSessionOptions` | `object` | `{ defaultElement, snap… }` — optional |
 | `boundaryConditions`, `isConventionalCellShown`, `initialViewSettings`, `isStandalone` | as today | Editing in conventional view: blocked or mapped back per D9 fix |
@@ -440,7 +440,7 @@ For resolution during this spec's review. Each: options → **recommendation**.
 | # | Decision | Options | Recommendation |
 |---|---|---|---|
 | D-1 | Undo/redo ownership | (a) wave owns intra-session, host records commits, ref API · (b) host owns all, wave stateless · (c) both (status quo) | **(a)** — matches the old modal's mental model; fixes MD's history flood with no host changes |
-| D-2 | Multi-material replacement | (a) `materials[]` prop + active index · (b) separate merge-workflow component · (c) drop capability, remove MD menu item | **(b) or explicit (c)** — an array complicates every callback; the decision can't be silent because MD's import breaks either way |
+| D-2 | Multi-material replacement | (a) `materials[]` prop + active index · (b) separate merge-workflow component · (c) drop capability, remove MD menu item | **Resolved 2026-08-01: neither (a) nor (b), in this repo.** The merge workflow (load N materials, position each as a rigid group via existing multi-select/group-transform, flatten to one material on commit) belongs in materials-designer, built on wave.js's existing single-material `ThreeDEditor` + group-transform primitives — not as new wave.js component surface. Two integration shapes MD can choose between, neither requiring wave.js changes today: (i) MD pre-merges materials into one (positioning offsets computed upstream) and hands `ThreeDEditor` a single material exactly as it does now; (ii) MD builds its own viewer against lower-level primitives (`Wave`, `createAtomsGroup`, `getUnitCellObject`), which would require exporting them from `src/exports.js` (currently only `ThreeDEditor` and the view-settings URL helpers are public) — deferred until MD actually needs it, so this package's public API doesn't grow speculatively. |
 | D-3 | Transactionality | (a) pure incremental (status quo) · (b) session commit-or-cancel · (c) hybrid: streaming + session-end commit | **(c)** — keeps live preview, restores the cancel guarantee, one host history entry per session |
 | D-4 | Rubber-band vs. orbit on empty-space drag (edit mode) | (a) drag = marquee, orbit needs modifier/RMB · (b) marquee needs `Shift`-drag · (c) explicit select-tool sub-mode (old `M` toggle) | **Decided and implemented 2026-07-14: (a)** — drag-on-empty-space is marquee select; orbit rotate moved to the right mouse button (`OrbitControls.mouseButtons` remapped while edit mode is active, restored on exit) |
 | D-5 | Default snap granularity | free (off) · fractional grid · nearest lattice site — all toggleable | **Off by default**, magnet toggle + `Ctrl/Cmd`-held snap; perturbation workflows dominate; the default exposed as a setting |
@@ -481,7 +481,7 @@ Phased; each phase lands with its regression tests. No code changes before this 
 
 ### P2 — roadmap items
 
-Per §11, gated on decisions D-2/D-5/D-6/D-7/D-9. (D-4 was resolved and implemented 2026-07-14 — see below; it no longer gates anything.)
+Per §11, gated on decisions D-5/D-6/D-7/D-9. (D-4 was resolved and implemented 2026-07-14 — see below; D-2 was resolved 2026-08-01 as out of scope for wave.js — see below; neither gates anything here anymore.)
 
 ## 11. Roadmap (designed, deferred)
 
@@ -498,8 +498,9 @@ While wiring group rotate, found and fixed a latent defect in `rebuildScene()` (
 | Snapping: fractional grid, lattice sites, snap-to-atom; magnet toggle + `Ctrl/Cmd` held | §3e, decision D-5 | Beyond old editor |
 | Keyboard nudge (arrows / `Shift`+arrows) | §3h, decision D-6 | Beyond old editor |
 | Periodic-wrap flag + one-click wrap for out-of-cell atoms | Decision D-7 | Beyond old editor |
-| Multi-material story | Decision D-2 | Yes — modal's merge workflow |
 | Configurable key bindings | Decision D-10 | Yes |
+
+Multi-material story (old-editor parity: yes, via the modal's merge workflow) is **not** a wave.js roadmap item — resolved 2026-08-01 by decision D-2 (§9) to live in materials-designer instead, built on this editor's existing single-material + group-transform primitives.
 
 Explicitly **out of scope** (dropped with the old editor, deliberately):
 

--- a/plan/interactive-editor-spec-plan.md
+++ b/plan/interactive-editor-spec-plan.md
@@ -46,7 +46,7 @@ Beyond the review's own findings, three further improvements were identified and
 | # | Decision | Status |
 |---|---|---|
 | D-1 | Undo ownership (wave vs. host vs. both) | Open |
-| D-2 | Multi-material editing replacement (materials-designer's deleted "Multi-Material 3D Editor") | Open — explicitly deferred 2026-07-14, not decided |
+| D-2 | Multi-material editing replacement (materials-designer's deleted "Multi-Material 3D Editor") | **Resolved 2026-08-01: out of scope for wave.js.** Belongs in materials-designer, built on this editor's existing single-material `ThreeDEditor` + group-transform primitives, not as new wave.js component surface. No wave.js code required unless MD chooses the lower-level-primitives integration path (§9, D-2) over pre-merging upstream — that would need `Wave`/`createAtomsGroup`/`getUnitCellObject` exported from `src/exports.js`, deferred until actually needed. |
 | D-3 | Transactionality (incremental vs. session commit/cancel vs. hybrid) | Open |
 | D-4 | Rubber-band multi-select vs. orbit-on-empty-space-drag | **Decided and implemented 2026-07-14; group rotate added 2026-08-01.** Translate and rotate are both shipped for a 2+ group. Double-click-selects-bonded-fragment stays deferred (needs bond connectivity data). |
 | D-5 | Default snap granularity (free/grid/lattice-site) | Open |
@@ -58,7 +58,7 @@ Beyond the review's own findings, three further improvements were identified and
 | D-11 | `postMessage` bridge fate | Resolved in P0 — removed entirely (no confirmed consumer) |
 | D-12 | Mode exclusivity (edit vs. measurement) | Resolved in P1 — mutually exclusive, per the spec's recommendation |
 
-Shipped so far: rubber-band multi-select + group translate/rotate about a centroid (D-4 — this is what restores the old editor's `MultipleSelectionControls` capability), type-to-change element rename + clone atom (D-9's type-to-change half), and camera focus-on-selection. Once the remaining open decisions are made, the rest becomes buildable: an Add-Atom element-picker (D-9's toolbar-picker half), lattice/fractional snapping (D-5/D-6), keyboard nudge (D-6), and the multi-material story (D-2).
+Shipped so far: rubber-band multi-select + group translate/rotate about a centroid (D-4 — this is what restores the old editor's `MultipleSelectionControls` capability), type-to-change element rename + clone atom (D-9's type-to-change half), and camera focus-on-selection. Once the remaining open decisions are made, the rest becomes buildable: an Add-Atom element-picker (D-9's toolbar-picker half), lattice/fractional snapping (D-5/D-6), keyboard nudge (D-6). The multi-material story (D-2) is resolved but not a wave.js buildable — it's materials-designer's to build, on top of what's already shipped here.
 
 Two things explicitly stay out of scope regardless of these decisions (spec §11): the old editor's generic 3D-authoring features (primitives, lights, materials editor, scripting) and its outliner/scene-tree panel — the new editor's structure state *is* the outliner, there's no separate group hierarchy to browse.
 


### PR DESCRIPTION
## Summary
- Resolves spec decision D-2 (multi-material replacement, §9): rather than a `materials[]` prop on `ThreeDEditor` or a new merge-workflow component in this repo, the merge workflow belongs in materials-designer — built on wave.js's existing single-material `ThreeDEditor` plus this session's group-transform primitives (select/drag/rotate a rigid group of atoms as one unit).
- Updates every place the spec/plan docs referenced D-2 as open or as a wave.js roadmap item: the decision table (§9), the `material` prop's notes (§6.2), the roadmap table (§11), and the plan doc's outstanding-decisions table + shipped-so-far summary.
- Notes two integration shapes for materials-designer to choose between, neither requiring wave.js changes today: pre-merge materials into one before handing `ThreeDEditor` a single material as usual, or build a custom viewer against lower-level primitives (`Wave`, `createAtomsGroup`, `getUnitCellObject`) — which would need those exported from `src/exports.js`, deliberately deferred until MD actually needs that path rather than growing the public API speculatively.
- Docs-only change. Fifth PR in the post-review chained-PR stack (stacked on [#209](https://github.com/mat3ra/wave.js/pull/209)).

## Test plan
- [x] Docs-only diff — no source files touched, `npm test`/`tsc`/`lint`/`build` unaffected.
- [x] Grepped both docs for every remaining `D-2` reference after editing to confirm nothing still reads it as open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)