### PR TITLE
feat(ui): touch and small-screen support (U-13)

### DIFF
--- a/dist/components/KeyboardSheet.d.ts
+++ b/dist/components/KeyboardSheet.d.ts
@@ -8,6 +8,16 @@ export interface KeyboardSheetProps {
     onClose?: () => void;
     /** Mirrors ThreeDEditor's prop: without it the edit bindings do not exist to advertise. */
     editable?: boolean;
+    /**
+     * Whether to list the touch gestures (U-13). Defaults to whether the device can produce touch
+     * input at all - see getKeyBindings - and is a prop so a test can assert both shapes.
+     */
+    includeTouch?: boolean;
+    /**
+     * Whether the primary pointer is coarse. Decides the group order (touch first where touch is how
+     * the viewer is driven) and suppresses the key-based close hint. A prop so a test can assert both.
+     */
+    isCoarsePointer?: boolean;
 }
 declare function KeyboardSheet(props: KeyboardSheetProps): import("react/jsx-runtime").JSX.Element;
 export default KeyboardSheet;

--- a/dist/components/KeyboardSheet.js
+++ b/dist/components/KeyboardSheet.js
@@ -1,11 +1,14 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Divider from "@mui/material/Divider";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
+import { hasCoarsePointer } from "../utils/inputCapabilities";
 import { getGroupedKeyBindings, getModifierLabel } from "../utils/keyBindings";
 function KeyRow({ label, keys }) {
     return (_jsxs(Stack, { direction: "row", spacing: 2, justifyContent: "space-between", alignItems: "baseline", children: [_jsx(Typography, { variant: "body2", color: "text.secondary", children: label }), _jsx(Box, { component: "kbd", sx: {
@@ -16,8 +19,21 @@ function KeyRow({ label, keys }) {
                 }, children: keys })] }));
 }
 function KeyboardSheet(props) {
-    const { isOpen = false, onClose, editable = true } = props;
-    const sections = getGroupedKeyBindings({ editable });
-    return (_jsxs(Dialog, { open: isOpen, onClose: onClose, maxWidth: "md", fullWidth: true, "aria-labelledby": "keyboard-sheet-title", "data-name": "KeyboardSheet", children: [_jsx(DialogTitle, { id: "keyboard-sheet-title", sx: { pb: 1 }, children: _jsxs(Stack, { direction: "row", justifyContent: "space-between", alignItems: "baseline", children: [_jsx(Typography, { variant: "h6", component: "span", children: "Keyboard shortcuts" }), _jsx(Typography, { variant: "caption", color: "text.secondary", children: "? or Esc to close" })] }) }), _jsxs(DialogContent, { children: [_jsx(Stack, { direction: { xs: "column", sm: "row" }, spacing: 4, divider: _jsx(Divider, { orientation: "vertical", flexItem: true }), alignItems: "flex-start", children: sections.map((section) => (_jsxs(Stack, { spacing: 0.75, sx: { flex: 1, minWidth: 0, width: "100%" }, "data-name": `KeyboardSheetGroup-${section.group}`, children: [_jsx(Typography, { variant: "caption", fontWeight: "bold", color: "primary.main", sx: { letterSpacing: "0.06em", textTransform: "uppercase" }, children: section.label }), section.bindings.map((binding) => (_jsx(KeyRow, { label: binding.label, keys: binding.keys }, `${binding.label}-${binding.keys}`)))] }, section.group))) }), _jsx(Divider, { sx: { my: 2 } }), _jsx(Typography, { variant: "caption", color: "text.secondary", children: `The modifier resolves per platform — Ctrl on Windows and Linux, Cmd on macOS; shown above as ${getModifierLabel()}. Edit mode and the measurement modes are mutually exclusive: arming a measurement leaves edit mode, and entering edit mode clears measurements.` })] })] }));
+    const { isOpen = false, onClose, editable = true, includeTouch, isCoarsePointer } = props;
+    const isCoarse = isCoarsePointer !== null && isCoarsePointer !== void 0 ? isCoarsePointer : hasCoarsePointer();
+    const sections = getGroupedKeyBindings({ editable, includeTouch, touchFirst: isCoarse });
+    return (_jsxs(Dialog, { open: isOpen, onClose: onClose, maxWidth: "md", fullWidth: true, "aria-labelledby": "keyboard-sheet-title", "data-name": "KeyboardSheet", children: [_jsx(DialogTitle, { id: "keyboard-sheet-title", sx: { pb: 1 }, children: _jsxs(Stack, { direction: "row", justifyContent: "space-between", alignItems: "baseline", children: [_jsx(Typography, { variant: "h6", component: "span", children: "Shortcuts & gestures" }), !isCoarse && (_jsx(Typography, { variant: "caption", color: "text.secondary", children: "? or Esc to close" }))] }) }), _jsxs(DialogContent, { children: [_jsx(Box, { sx: {
+                            display: "grid",
+                            // A grid rather than a row of columns: the touch group (U-13) makes four,
+                            // and four fixed columns crush the labels on the narrow screens that group
+                            // exists for. auto-fit reflows to one column on a phone by itself.
+                            gridTemplateColumns: {
+                                xs: "1fr",
+                                sm: "repeat(auto-fit, minmax(190px, 1fr))",
+                            },
+                            columnGap: 4,
+                            rowGap: 2.5,
+                            alignItems: "start",
+                        }, children: sections.map((section) => (_jsxs(Stack, { spacing: 0.75, sx: { minWidth: 0, width: "100%" }, "data-name": `KeyboardSheetGroup-${section.group}`, children: [_jsx(Typography, { variant: "caption", fontWeight: "bold", color: "primary.main", sx: { letterSpacing: "0.06em", textTransform: "uppercase" }, children: section.label }), section.bindings.map((binding) => (_jsx(KeyRow, { label: binding.label, keys: binding.keys }, `${binding.label}-${binding.keys}`)))] }, section.group))) }), _jsx(Divider, { sx: { my: 2 } }), _jsx(Typography, { variant: "caption", color: "text.secondary", children: `The modifier resolves per platform — Ctrl on Windows and Linux, Cmd on macOS; shown above as ${getModifierLabel()}. Edit mode and the measurement modes are mutually exclusive: arming a measurement leaves edit mode, and entering edit mode clears measurements.` })] }), _jsx(DialogActions, { children: _jsx(Button, { onClick: onClose, "data-name": "KeyboardSheetClose", children: "Close" }) })] }));
 }
 export default KeyboardSheet;

--- a/dist/components/ModePill.d.ts
+++ b/dist/components/ModePill.d.ts
@@ -32,12 +32,17 @@ export interface ModePillProps {
 /**
  * Bindings worth stating in the pill, sourced from settings so a rebind cannot desync them.
  *
- * `isOrbitEnabled` gates the right-button note. Orbit controls start disabled
+ * `isOrbitEnabled` gates the orbit note. Orbit controls start disabled
  * (`initOrbitControls(enabled = false)`), so while they are off the right button orbits nothing -
  * and advertising a binding that does nothing is the defect this whole slice is trying to undo.
+ *
+ * `isCoarsePointer` decides *which* orbit gesture is named. A phone has no right button, and edit
+ * mode reserves one finger for atoms exactly as it frees the left button, so there the camera is on
+ * two fingers (U-13). Naming the mouse binding on a touch device would be the same class of lie.
  */
-export declare function getEditModeBindings({ isOrbitEnabled, }?: {
+export declare function getEditModeBindings({ isOrbitEnabled, isCoarsePointer, }?: {
     isOrbitEnabled?: boolean;
+    isCoarsePointer?: boolean;
 }): string[];
 declare function ModePill(props: ModePillProps): import("react/jsx-runtime").JSX.Element | null;
 export default ModePill;

--- a/dist/components/ModePill.js
+++ b/dist/components/ModePill.js
@@ -6,6 +6,7 @@ import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import settings from "../settings";
+import { hasCoarsePointer } from "../utils/inputCapabilities";
 import { formatMeasurementValue, getMeasurementHint, getMeasurementLabel, getMeasurementProgress, } from "../utils/measurementReadout";
 import { useObservedWidth } from "../utils/useObservedWidth";
 import { INSPECTOR_WIDTH } from "./SelectionInspector";
@@ -45,28 +46,43 @@ const EDIT_SURFACE_INSET = `calc(${SIDE_CHROME_INSET} + ${INSPECTOR_WIDTH} + 8px
 /**
  * Bindings worth stating in the pill, sourced from settings so a rebind cannot desync them.
  *
- * `isOrbitEnabled` gates the right-button note. Orbit controls start disabled
+ * `isOrbitEnabled` gates the orbit note. Orbit controls start disabled
  * (`initOrbitControls(enabled = false)`), so while they are off the right button orbits nothing -
  * and advertising a binding that does nothing is the defect this whole slice is trying to undo.
+ *
+ * `isCoarsePointer` decides *which* orbit gesture is named. A phone has no right button, and edit
+ * mode reserves one finger for atoms exactly as it frees the left button, so there the camera is on
+ * two fingers (U-13). Naming the mouse binding on a touch device would be the same class of lie.
  */
-export function getEditModeBindings({ isOrbitEnabled = false, } = {}) {
+export function getEditModeBindings({ isOrbitEnabled = false, isCoarsePointer = hasCoarsePointer(), } = {}) {
     var _a;
     const keys = settings.hotKeysConfig;
     const orbitKey = (_a = keys === null || keys === void 0 ? void 0 : keys.toggleOrbitControls) === null || _a === void 0 ? void 0 : _a.toUpperCase();
     // The remap that surprises people: in edit mode a left-drag on empty space marquees, so orbit
-    // moves to the right button (D-4). That is only true once orbit is on, so while it is off the
-    // pill points at the key that turns it on instead of naming a button that does nothing.
+    // moves to the right button (D-4) - or to two fingers on touch. That is only true once orbit is
+    // on, so while it is off the pill points at the way to turn it on instead.
     let orbitNote = "";
     if (isOrbitEnabled)
-        orbitNote = "RMB = orbit";
+        orbitNote = isCoarsePointer ? "2 fingers = orbit" : "RMB = orbit";
+    else if (isCoarsePointer)
+        orbitNote = "Rotate/Zoom off";
     else if (orbitKey)
         orbitNote = `${orbitKey} = enable orbit`;
+    // Keyboard rows are dropped on a coarse pointer: Del and Esc name keys a phone does not have,
+    // and the toolbar's Remove button is the reachable equivalent.
+    const keyboardNotes = isCoarsePointer
+        ? []
+        : [
+            "Del = remove",
+            "Esc = deselect",
+            (keys === null || keys === void 0 ? void 0 : keys.focusCameraOnSelection)
+                ? `${keys.focusCameraOnSelection.toUpperCase()} = focus`
+                : "",
+        ];
     return [
-        "drag = move",
+        isCoarsePointer ? "drag atom = move" : "drag = move",
         orbitNote,
-        "Del = remove",
-        "Esc = deselect",
-        (keys === null || keys === void 0 ? void 0 : keys.focusCameraOnSelection) ? `${keys.focusCameraOnSelection.toUpperCase()} = focus` : "",
+        ...keyboardNotes,
     ].filter(Boolean);
 }
 function Pill({ label, accent, children, onExit, exitTitle, dataName }) {
@@ -112,8 +128,8 @@ function ModePill(props) {
             position: "absolute",
             top: "1em",
             // Insets clear the chrome pinned to either edge - the icon strip on the left, the edit
-            // toolbar on the right. Spanning the full width let the pill grow to 520 px and run
-            // underneath both of them, which is what an embedded viewer showed first.
+            // toolbar and inspector on the right. Spanning the full width let the pill grow to
+            // 520 px and run underneath all of them, which an embedded viewer showed first.
             left: SIDE_CHROME_INSET,
             right: isEditModeActive ? EDIT_SURFACE_INSET : SIDE_CHROME_INSET,
             // The canvas keeps its pointer events; each pill opts back in for itself.

--- a/dist/components/QuickToggles.js
+++ b/dist/components/QuickToggles.js
@@ -3,6 +3,7 @@ import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
+import { COARSE_POINTER_QUERY, TOUCH_TARGET_MIN_PX } from "../utils/inputCapabilities";
 function QuickToggles({ items = [] }) {
     if (!items.length)
         return null;
@@ -30,6 +31,16 @@ function QuickToggles({ items = [] }) {
                             height: 32,
                             p: 0,
                             borderRadius: "16px",
+                            // Grown to the touch minimum on coarse pointers only (U-13): a
+                            // 32 px circle is a comfortable mouse target and an unreliable
+                            // finger one, and this row is the primary control surface on a
+                            // phone, where the toolbar menus are the awkward path.
+                            [`@media ${COARSE_POINTER_QUERY}`]: {
+                                width: TOUCH_TARGET_MIN_PX,
+                                height: TOUCH_TARGET_MIN_PX,
+                                borderRadius: `${TOUCH_TARGET_MIN_PX / 2}px`,
+                                "& svg": { fontSize: "1.35rem" },
+                            },
                             cursor: "pointer",
                             border: 1,
                             borderColor: item.isActive ? "primary.light" : "divider",

--- a/dist/components/ThreeDEditor.d.ts
+++ b/dist/components/ThreeDEditor.d.ts
@@ -309,6 +309,15 @@ export class ThreeDEditor extends React.Component<any, any, any> {
         rightIcon?: undefined;
         onClick?: undefined;
         shouldMenuStayOpened?: undefined;
+    } | {
+        id: string;
+        disabled: boolean;
+        content: string;
+        leftIcon: import("react/jsx-runtime").JSX.Element;
+        onClick: () => void;
+        rightIcon?: undefined;
+        shouldMenuStayOpened?: undefined;
+        isDivider?: undefined;
     })[];
     getMeasurementsActions: () => ({
         id: string;
@@ -409,6 +418,15 @@ export class ThreeDEditor extends React.Component<any, any, any> {
             rightIcon?: undefined;
             onClick?: undefined;
             shouldMenuStayOpened?: undefined;
+        } | {
+            id: string;
+            disabled: boolean;
+            content: string;
+            leftIcon: import("react/jsx-runtime").JSX.Element;
+            onClick: () => void;
+            rightIcon?: undefined;
+            shouldMenuStayOpened?: undefined;
+            isDivider?: undefined;
         })[];
         onClick: () => void;
         contentObject?: undefined;

--- a/dist/components/ThreeDEditor.js
+++ b/dist/components/ThreeDEditor.js
@@ -17,6 +17,7 @@ import Edit from "@mui/icons-material/Edit";
 import FormatShapes from "@mui/icons-material/FormatShapes";
 import GpsFixed from "@mui/icons-material/GpsFixed";
 import HeightIcon from "@mui/icons-material/Height";
+import HelpOutline from "@mui/icons-material/HelpOutline";
 import Image from "@mui/icons-material/Image";
 import ImportExport from "@mui/icons-material/ImportExport";
 import LooksIcon from "@mui/icons-material/Looks";
@@ -208,6 +209,20 @@ export class ThreeDEditor extends React.Component {
                     leftIcon: _jsx(Replay, {}),
                     onClick: this.handleResetViewer,
                     shouldMenuStayOpened: true,
+                },
+                {
+                    id: "divider-help",
+                    isDivider: true,
+                },
+                {
+                    // The sheet was reachable only by pressing `?` (U-3), which is unreachable on a
+                    // device with no keyboard - so the one surface documenting how to drive the viewer
+                    // was missing exactly where a user most needs it (U-13). The key still works.
+                    id: "keyboard-sheet",
+                    disabled: false,
+                    content: "Shortcuts & gestures",
+                    leftIcon: _jsx(HelpOutline, {}),
+                    onClick: this.handleToggleKeyboardSheet,
                 },
             ];
         };

--- a/dist/mixins/interactive_structure_editor.d.ts
+++ b/dist/mixins/interactive_structure_editor.d.ts
@@ -31,6 +31,7 @@ export declare const InteractiveStructureEditorMixin: (superclass: any) => {
         activePointerId_: number | null;
         orbitControlsEnabledBeforeDrag_: boolean;
         orbitControlsDefaultMouseButtons_: any | null;
+        orbitControlsDefaultTouches_: any | null;
         lastSelectedAtomicIndices_: number[] | null;
         handlePointerDownCapture_: ((event: PointerEvent) => void) | null;
         handlePointerMoveCapture_: ((event: PointerEvent) => void) | null;
@@ -180,6 +181,12 @@ export declare const InteractiveStructureEditorMixin: (superclass: any) => {
          * OrbitControls left mouse button off (freeing it for marquee-select on empty space) and
          * moves camera rotation onto the right mouse button (decision D-4); the defaults are
          * restored on disable.
+         *
+         * Touch gets the same treatment for the same reason (U-13). OrbitControls' default
+         * `touches.ONE` is ROTATE, which is the finger the editor needs for selecting, dragging an
+         * atom and marquee-selecting - so while edit mode is on, one finger belongs to the editor and
+         * the camera moves to two fingers (DOLLY_ROTATE: pinch to zoom, twist to orbit). There is no
+         * right button to move it to.
          * @param {boolean} enabled - True to enable, false to disable.
          */
         enableEditMode(enabled: boolean): void;

--- a/dist/mixins/interactive_structure_editor.js
+++ b/dist/mixins/interactive_structure_editor.js
@@ -6,6 +6,15 @@ const SELECTION_HIGHLIGHT_COLOR = 0x0969da;
 const HIGHLIGHT_SCALE_FACTOR = 1.25;
 const DRAG_COMMIT_EPSILON = 1e-6;
 /**
+ * Value put in OrbitControls' `touches.ONE` while edit mode owns the first finger (U-13).
+ *
+ * OrbitControls has no "no gesture" constant for touch the way `mouseButtons` accepts null: its
+ * `onTouchStart` switches on `touches.ONE` over TOUCH.ROTATE and TOUCH.PAN and falls through to
+ * `STATE.NONE` for anything else. Deliberately outside the enum (TOUCH runs 0-3), and named so the
+ * next reader does not "fix" it into a real gesture.
+ */
+const ONE_FINGER_RESERVED_FOR_EDITING = -1;
+/**
  * Mixin providing interactive structure editing capabilities inside the Wave visualizer.
  * Enforces strict object-oriented design and follows the "6 months x 3 beers" rule for comments.
  */
@@ -32,6 +41,7 @@ export const InteractiveStructureEditorMixin = (superclass) => class extends sup
         this.activePointerId_ = null;
         this.orbitControlsEnabledBeforeDrag_ = true;
         this.orbitControlsDefaultMouseButtons_ = null;
+        this.orbitControlsDefaultTouches_ = null;
         this.lastSelectedAtomicIndices_ = null;
         this.handlePointerDownCapture_ = null;
         this.handlePointerMoveCapture_ = null;
@@ -685,6 +695,12 @@ export const InteractiveStructureEditorMixin = (superclass) => class extends sup
      * OrbitControls left mouse button off (freeing it for marquee-select on empty space) and
      * moves camera rotation onto the right mouse button (decision D-4); the defaults are
      * restored on disable.
+     *
+     * Touch gets the same treatment for the same reason (U-13). OrbitControls' default
+     * `touches.ONE` is ROTATE, which is the finger the editor needs for selecting, dragging an
+     * atom and marquee-selecting - so while edit mode is on, one finger belongs to the editor and
+     * the camera moves to two fingers (DOLLY_ROTATE: pinch to zoom, twist to orbit). There is no
+     * right button to move it to.
      * @param {boolean} enabled - True to enable, false to disable.
      */
     enableEditMode(enabled) {
@@ -697,10 +713,25 @@ export const InteractiveStructureEditorMixin = (superclass) => class extends sup
                     LEFT: null,
                     RIGHT: THREE.MOUSE.ROTATE,
                 };
+                this.orbitControlsDefaultTouches_ = { ...this.orbitControls.touches };
+                this.orbitControls.touches = {
+                    // OrbitControls switches on `touches.ONE` and falls through to STATE.NONE
+                    // for anything it does not recognise, which is how a one-finger gesture is
+                    // handed to the editor - the same "no camera on this input" intent as
+                    // LEFT: null above, expressed the only way the touch path allows.
+                    ONE: ONE_FINGER_RESERVED_FOR_EDITING,
+                    TWO: THREE.TOUCH.DOLLY_ROTATE,
+                };
             }
-            else if (this.orbitControlsDefaultMouseButtons_) {
-                this.orbitControls.mouseButtons = this.orbitControlsDefaultMouseButtons_;
-                this.orbitControlsDefaultMouseButtons_ = null;
+            else {
+                if (this.orbitControlsDefaultMouseButtons_) {
+                    this.orbitControls.mouseButtons = this.orbitControlsDefaultMouseButtons_;
+                    this.orbitControlsDefaultMouseButtons_ = null;
+                }
+                if (this.orbitControlsDefaultTouches_) {
+                    this.orbitControls.touches = this.orbitControlsDefaultTouches_;
+                    this.orbitControlsDefaultTouches_ = null;
+                }
             }
         }
         if (!enabled) {

--- a/dist/utils/inputCapabilities.d.ts
+++ b/dist/utils/inputCapabilities.d.ts
@@ -1,0 +1,42 @@
+/**
+ * What kind of pointer is driving the viewer (U-13).
+ *
+ * `IconsToolbar` computed `isMobile` from `theme.breakpoints.down("sm")` and forwarded it to exactly
+ * one dropdown; nothing else in the viewer adapted. That is the half-support the proposal called the
+ * worst of the three options, and it asked the wrong question twice over: a narrow browser window on
+ * a desktop is not touch input, and a 13-inch touch laptop is, at any width. What actually decides
+ * whether a 32 px control is reachable, whether a hover tooltip can ever be seen, and whether "right
+ * button" names anything real is the *pointer*, not the viewport.
+ *
+ * So capability queries, read at call time rather than at module load, because a window can move to
+ * another display and a tablet can gain a keyboard mid-session.
+ */
+/** Devices whose primary pointer has coarse accuracy: fingers, and styluses without hover. */
+export declare const COARSE_POINTER_QUERY = "(pointer: coarse)";
+/** Devices that cannot hover, so anything living only in a tooltip is unreachable. */
+export declare const NO_HOVER_QUERY = "(hover: none)";
+/**
+ * Minimum comfortable touch target. 44 px is the long-standing platform guidance (WCAG 2.2's
+ * Target Size (Minimum) sets 24 px as the floor; 44 is what a finger actually wants).
+ */
+export declare const TOUCH_TARGET_MIN_PX = 44;
+export declare function hasCoarsePointer(): boolean;
+export declare function hasNoHover(): boolean;
+/**
+ * Whether the device can produce touch input at all - which is not the same question as whether the
+ * *primary* pointer is coarse. A touch laptop reports a fine primary pointer and still needs the
+ * touch gestures documented, so this is what gates the gesture list while `hasCoarsePointer` gates
+ * sizing.
+ */
+export declare function hasTouchSupport(): boolean;
+/**
+ * `sx` fragment enlarging a control to the touch minimum on coarse pointers only, so a mouse-driven
+ * viewer keeps its compact chrome. Applied as a media query rather than a breakpoint for the reason
+ * in the module comment.
+ */
+export declare const coarsePointerTargetSx: {
+    "@media (pointer: coarse)": {
+        minWidth: string;
+        minHeight: string;
+    };
+};

--- a/dist/utils/inputCapabilities.js
+++ b/dist/utils/inputCapabilities.js
@@ -1,0 +1,65 @@
+/**
+ * What kind of pointer is driving the viewer (U-13).
+ *
+ * `IconsToolbar` computed `isMobile` from `theme.breakpoints.down("sm")` and forwarded it to exactly
+ * one dropdown; nothing else in the viewer adapted. That is the half-support the proposal called the
+ * worst of the three options, and it asked the wrong question twice over: a narrow browser window on
+ * a desktop is not touch input, and a 13-inch touch laptop is, at any width. What actually decides
+ * whether a 32 px control is reachable, whether a hover tooltip can ever be seen, and whether "right
+ * button" names anything real is the *pointer*, not the viewport.
+ *
+ * So capability queries, read at call time rather than at module load, because a window can move to
+ * another display and a tablet can gain a keyboard mid-session.
+ */
+/** Devices whose primary pointer has coarse accuracy: fingers, and styluses without hover. */
+export const COARSE_POINTER_QUERY = "(pointer: coarse)";
+/** Devices that cannot hover, so anything living only in a tooltip is unreachable. */
+export const NO_HOVER_QUERY = "(hover: none)";
+/**
+ * Minimum comfortable touch target. 44 px is the long-standing platform guidance (WCAG 2.2's
+ * Target Size (Minimum) sets 24 px as the floor; 44 is what a finger actually wants).
+ */
+export const TOUCH_TARGET_MIN_PX = 44;
+function matches(query) {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function")
+        return false;
+    try {
+        return window.matchMedia(query).matches;
+    }
+    catch (error) {
+        // jsdom and some embedded webviews implement matchMedia partially; an unsupported query
+        // should read as "not coarse" rather than take the viewer down.
+        return false;
+    }
+}
+export function hasCoarsePointer() {
+    return matches(COARSE_POINTER_QUERY);
+}
+export function hasNoHover() {
+    return matches(NO_HOVER_QUERY);
+}
+/**
+ * Whether the device can produce touch input at all - which is not the same question as whether the
+ * *primary* pointer is coarse. A touch laptop reports a fine primary pointer and still needs the
+ * touch gestures documented, so this is what gates the gesture list while `hasCoarsePointer` gates
+ * sizing.
+ */
+export function hasTouchSupport() {
+    if (typeof navigator !== "undefined" && typeof navigator.maxTouchPoints === "number") {
+        return navigator.maxTouchPoints > 0;
+    }
+    if (typeof window !== "undefined" && "ontouchstart" in window)
+        return true;
+    return hasCoarsePointer();
+}
+/**
+ * `sx` fragment enlarging a control to the touch minimum on coarse pointers only, so a mouse-driven
+ * viewer keeps its compact chrome. Applied as a media query rather than a breakpoint for the reason
+ * in the module comment.
+ */
+export const coarsePointerTargetSx = {
+    [`@media ${COARSE_POINTER_QUERY}`]: {
+        minWidth: `${TOUCH_TARGET_MIN_PX}px`,
+        minHeight: `${TOUCH_TARGET_MIN_PX}px`,
+    },
+};

--- a/dist/utils/keyBindings.d.ts
+++ b/dist/utils/keyBindings.d.ts
@@ -9,7 +9,7 @@
  * Generating the sheet from here means a rebind updates the label with it. Defect D2 - a tooltip
  * that promised a hotkey which did not exist - was the same drift running the other way.
  */
-export type BindingGroup = "view" | "edit" | "measure";
+export type BindingGroup = "view" | "edit" | "measure" | "touch";
 export interface KeyBinding {
     /** What the binding does, in the user's terms. */
     label: string;
@@ -18,6 +18,12 @@ export interface KeyBinding {
     group: BindingGroup;
     /** A pointer gesture rather than a key - grouped the same, rendered the same. */
     isGesture?: boolean;
+    /**
+     * Only meaningful in edit mode. The mouse gestures express this through `group: "edit"`, but the
+     * touch rows are grouped by input device instead, so they carry it explicitly - filtering them by
+     * matching label text would break silently the first time a label is reworded.
+     */
+    editOnly?: boolean;
 }
 export interface EditorKeyDefinition {
     keys: string[];
@@ -38,13 +44,29 @@ export declare const BINDING_GROUP_LABELS: Record<BindingGroup, string>;
 /**
  * Every binding, grouped. `editable` mirrors the component prop: without it there is no edit mode,
  * so advertising its keys would promise something the viewer will not do.
+ *
+ * `includeTouch` defaults to whether the device can produce touch input at all, rather than to
+ * whether the primary pointer is coarse: a touch laptop drives the viewer with a trackpad and still
+ * needs the gestures documented. Keyboard rows stay visible either way - a tablet with a keyboard is
+ * an ordinary configuration, and hiding them would be the mirror image of the F3 discoverability
+ * problem this file exists to fix.
  */
-export declare function getKeyBindings({ editable }?: {
+export declare function getKeyBindings({ editable, includeTouch, }?: {
     editable?: boolean;
+    includeTouch?: boolean;
 }): KeyBinding[];
-/** The same bindings bucketed by group, skipping groups that came out empty. */
+/**
+ * The same bindings bucketed by group, skipping groups that came out empty.
+ *
+ * `touchFirst` moves the touch group to the front. On a phone the sheet reflows to a single column,
+ * so a group's position is how far the user has to scroll to reach it - and putting the gestures that
+ * are the only way to drive that device below three groups of keyboard shortcuts buries the one
+ * section they came for.
+ */
 export declare function getGroupedKeyBindings(options?: {
     editable?: boolean;
+    includeTouch?: boolean;
+    touchFirst?: boolean;
 }): {
     group: BindingGroup;
     label: string;

--- a/dist/utils/keyBindings.js
+++ b/dist/utils/keyBindings.js
@@ -1,4 +1,5 @@
 import settings from "../settings";
+import { hasTouchSupport } from "./inputCapabilities";
 /** True when `event` matches the given editor key definition. */
 export function matchesEditorKey(event, definition) {
     var _a;
@@ -48,6 +49,40 @@ const POINTER_GESTURES = [
     { label: "Orbit while editing", keys: "right-drag", group: "edit", isGesture: true },
     { label: "Move atom / group", keys: "drag atom", group: "edit", isGesture: true },
 ];
+/**
+ * Touch gestures (U-13). Listed separately because they are not alternative labels for the mouse
+ * gestures above - the mapping genuinely differs. In edit mode one finger is reserved for atoms, the
+ * same way the left button is (decision D-4), so orbiting moves to two fingers rather than the right
+ * button, which touch does not have.
+ *
+ * Every row here has to be true of the running build: this list existing at all is only an
+ * improvement if a user who follows it gets the result it promises.
+ */
+const TOUCH_GESTURES = [
+    {
+        label: "Rotate (once Rotate/Zoom is on)",
+        keys: "one-finger drag",
+        group: "touch",
+        isGesture: true,
+    },
+    { label: "Zoom", keys: "pinch", group: "touch", isGesture: true },
+    { label: "Pan", keys: "two-finger drag", group: "touch", isGesture: true },
+    { label: "Select atom", keys: "tap", group: "touch", isGesture: true, editOnly: true },
+    {
+        label: "Move atom / group",
+        keys: "drag atom",
+        group: "touch",
+        isGesture: true,
+        editOnly: true,
+    },
+    {
+        label: "Orbit while editing",
+        keys: "two fingers",
+        group: "touch",
+        isGesture: true,
+        editOnly: true,
+    },
+];
 /** Configured single-character keys, in the order they should read, with their group. */
 const HOTKEY_ROWS = [
     { setting: "toggleInteractive", label: "Interactive on / off", group: "view" },
@@ -75,12 +110,19 @@ export const BINDING_GROUP_LABELS = {
     view: "View & camera",
     edit: "Select & edit",
     measure: "Measure",
+    touch: "Touch",
 };
 /**
  * Every binding, grouped. `editable` mirrors the component prop: without it there is no edit mode,
  * so advertising its keys would promise something the viewer will not do.
+ *
+ * `includeTouch` defaults to whether the device can produce touch input at all, rather than to
+ * whether the primary pointer is coarse: a touch laptop drives the viewer with a trackpad and still
+ * needs the gestures documented. Keyboard rows stay visible either way - a tablet with a keyboard is
+ * an ordinary configuration, and hiding them would be the mirror image of the F3 discoverability
+ * problem this file exists to fix.
  */
-export function getKeyBindings({ editable = true } = {}) {
+export function getKeyBindings({ editable = true, includeTouch, } = {}) {
     const hotKeys = settings.hotKeysConfig;
     const editorKeys = settings.editorKeysConfig;
     const fromHotKeys = HOTKEY_ROWS.filter((row) => hotKeys[row.setting] && (editable || row.group !== "edit")).map((row) => ({
@@ -103,12 +145,26 @@ export function getKeyBindings({ editable = true } = {}) {
     const gestures = editable
         ? POINTER_GESTURES
         : POINTER_GESTURES.filter((gesture) => gesture.group !== "edit");
-    return [...fromHotKeys, ...fromEditorKeys, ...gestures];
+    const showTouch = includeTouch !== null && includeTouch !== void 0 ? includeTouch : hasTouchSupport();
+    const touchGestures = showTouch
+        ? TOUCH_GESTURES.filter((gesture) => editable || !gesture.editOnly)
+        : [];
+    return [...fromHotKeys, ...fromEditorKeys, ...gestures, ...touchGestures];
 }
-/** The same bindings bucketed by group, skipping groups that came out empty. */
+/**
+ * The same bindings bucketed by group, skipping groups that came out empty.
+ *
+ * `touchFirst` moves the touch group to the front. On a phone the sheet reflows to a single column,
+ * so a group's position is how far the user has to scroll to reach it - and putting the gestures that
+ * are the only way to drive that device below three groups of keyboard shortcuts buries the one
+ * section they came for.
+ */
 export function getGroupedKeyBindings(options = {}) {
     const all = getKeyBindings(options);
-    return ["view", "edit", "measure"]
+    const order = options.touchFirst
+        ? ["touch", "view", "edit", "measure"]
+        : ["view", "edit", "measure", "touch"];
+    return order
         .map((group) => ({
         group,
         label: BINDING_GROUP_LABELS[group],

--- a/dist/wave.js
+++ b/dist/wave.js
@@ -71,6 +71,12 @@ class WaveBase {
         this.renderer.sortObjects = false;
         this.renderer.domElement.style.width = "100%";
         this.renderer.domElement.style.height = "100%";
+        // Without this the browser claims touch drags for scrolling and pinch-zooming the page, and
+        // sends `pointercancel` to everything that had started tracking the gesture - so on a phone
+        // or a touch laptop no drag ever reached the viewer: not orbiting, not dragging an atom, not
+        // marquee-selecting (U-13). Every pointer handler in the editor is already pointer-event
+        // based, so this one declaration is what makes them work with a finger.
+        this.renderer.domElement.style.touchAction = "none";
         this.container.appendChild(this.renderer.domElement);
         this.renderer.setSize(this.WIDTH, this.HEIGHT);
         // Observes the container itself (not the window) so resizing works correctly when the

--- a/docs/design/uiux-improvements-2026-08.md
+++ b/docs/design/uiux-improvements-2026-08.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | P0, P1 and U-12 shipped 2026-08-12 (§0.1). U-13 (touch) is a follow-up PR stacked on this one. |
+| **Status** | All of P0, P1 and P2 shipped 2026-08-12 (§0.1) — U-13 via a PR stacked on the rest. Every U-n is implemented. |
 | **Date** | 2026-08-12 |
 | **Scope** | The viewer's own chrome: toolbars, panels, feedback, discoverability. Not the interaction model (settled in the [editor spec](./interactive-editor-spec.md)), not rendering. |
 | **Basis** | Read of `ThreeDEditor.jsx`, `IconsToolbar.tsx`, `ParametersMenu.tsx`, `SquareIconButton.tsx`, `settings.ts`, `main.css`; the editor spec's own R-register; the [status analysis](../codebase-status-2026-08.md). Prior art: VESTA, CrystalMaker, Avogadro 2, Blender, Figma. |
@@ -27,7 +27,7 @@ The three highest-value additions are a **status bar**, a **mode pill**, and a *
 
 ## 0.1 What shipped
 
-P0, P1 and U-12 are implemented as a branch chain off this document's branch, one branch per item, opened as a single PR ([#214](https://github.com/mat3ra/wave.js/pull/214)) intended to squash-land. U-13 sits in its own PR on top, so this one stops growing:
+All thirteen proposals are implemented as a branch chain off this document's branch, one branch per item. P0, P1 and U-12 are one PR ([#214](https://github.com/mat3ra/wave.js/pull/214)); U-13 is a second PR stacked on it, because it is the only item that changes how existing input is handled rather than adding a surface. Both are intended to squash-land:
 
 | # | Branch | Commit | Tests |
 |---|---|---|---|
@@ -43,9 +43,10 @@ P0, P1 and U-12 are implemented as a branch chain off this document's branch, on
 | U-7 | `claude/uiux-p1-quick-toggles` | `319447c` | 8 |
 | U-8 | `claude/uiux-p1-parameters` | `7972622` | 15 |
 | U-12 | `claude/uiux-p2-figure-export` | `e4fb816` | 70 |
+| U-13 | `claude/uiux-p2-touch-support` | `b7f01b2` | 32 |
 
-`tsc --noEmit` and `npm run lint` are clean on the tip, and the whole suite passes: **410 passing**,
-28 suites, up from 185 at the branch point. The 17 visual-snapshot failures that were red throughout
+`tsc --noEmit` and `npm run lint` are clean on the tip, and the whole suite passes: **440 passing**,
+30 suites, up from 185 at the branch point. The 17 visual-snapshot failures that were red throughout
 this work were never caused by it — reproduced exactly on the branch point — and were fixed by
 regenerating the baselines the van der Waals radii fix (`7e3541f`) had invalidated (`5882636`, §4).
 Every surface was also driven in Chromium against the **production bundle**, not just the dev server.
@@ -81,6 +82,11 @@ Every surface was also driven in Chromium against the **production bundle**, not
    screen is still the common case and should not pay for a dialog. Figure export is the separate,
    publication case. Its scale bar is exact only under the orthographic camera, and the dialog says
    so rather than presenting a perspective approximation as a measurement.
+10. **U-13 sizes by pointer, not by viewport.** The `isMobile` it replaces asked the wrong question:
+    a narrow desktop window is not touch input, and a touch laptop is touch input at full width.
+    Sizing keys off `(pointer: coarse)`; the gesture documentation keys off whether touch exists at
+    all, so a touch laptop gets the gestures listed and keeps its compact chrome. No bottom sheet was
+    needed — the existing layout was measured at 390 px and fits.
 
 Recorded so they are not re-investigated: the View menu reporting *Rotate/Zoom* as off at startup
 is correct, not rough edge R7's desync — orbit really is off until toggled
@@ -92,7 +98,12 @@ Three layout bugs were found by measuring the live DOM rather than by eye, all i
 a clipped third coordinate field, MUI's `InputBase` 75 px `min-width` overriding its grid column,
 and slider mark labels overlapping a caption. None were visible in jsdom.
 
-**Pre-existing bugs U-12 surfaced**, fixed with it because each was load-bearing for it:
+**Pre-existing bugs the P2 work surfaced**, fixed with it because each was load-bearing for the
+feature that found it:
+
+- The canvas had `touch-action: auto`, so the browser claimed every touch drag for page scroll and
+  pinch-zoom and sent `pointercancel` to whatever had begun tracking it. No touch drag ever reached
+  any of the editor's pointer handlers, even though all of them are pointer-event based.
 
 - `setOrthographicCameraFrustum` never called `updateProjectionMatrix`, so from construction until
   the first resize the orthographic camera projected the initial ±10 frustum from `initCameras`
@@ -172,7 +183,7 @@ U-1 also gives accessibility a foothold for free: it is the natural `aria-live="
 | # | Proposal | Decision | Effort |
 |---|---|---|---|
 | **U-12** | **Figure export.** A small dialog for the publication case: white or transparent background, fixed pixel size independent of the on-screen canvas, chrome excluded, optionally a scale bar. Today every screenshot bakes in the dark theme at whatever size the canvas happens to be. | **Shipped (§0.1). wave.js owns it:** the render needs the scene graph, camera frustum and renderer clear state; a host has none of those and can only screenshot the canvas — the thing that does not work. The file handoff stays with the host. | 2.5 |
-| **U-13** | **Touch and small-screen support.** Either adapt properly — bottom sheet instead of a pinned strip, larger hit targets, a documented touch gesture set — or state that the viewer is desktop-only and stop half-computing `isMobile`. | Implemented in a **follow-up PR stacked on this one**, so it can be reviewed and reverted on its own — it is the only item here that changes how existing input is handled rather than adding a surface. | 1.5 |
+| **U-13** | **Touch and small-screen support.** Either adapt properly — bottom sheet instead of a pinned strip, larger hit targets, a documented touch gesture set — or state that the viewer is desktop-only and stop half-computing `isMobile`. | **Shipped (§0.1) as a stacked PR** — separate because it is the only item that changes how existing input is handled rather than adding a surface. **Adapt, but not as a port:** the layout already fits at 390 px (measured); what was missing was gesture ownership, finger-sized targets and honest labels. No bottom sheet, no viewport-width branching, `isMobile` replaced by pointer capability. | 1.5 |
 
 ## 4. Suggested order
 
@@ -180,17 +191,16 @@ U-1 also gives accessibility a foothold for free: it is the natural `aria-live="
 2. **U-4, U-5** as drive-by fixes alongside — half a day each, and U-5 unblocks the S-1 cleanup.
 3. **U-6, U-7** next: this is the real restructuring, and F1 is a functional defect, not a matter of taste.
 4. **U-8, U-9, U-10, U-11** in any order; independent of each other.
-5. **U-12, U-13** only once their decisions are made. *(Both decided — each answered its own scope
-   question once the code was in front of it, which is worth remembering the next time a slice is
-   held for a decision that only the implementation can inform. U-12 is here; U-13 is the stacked
-   follow-up.)*
+5. **U-12, U-13** only once their decisions are made. *(Both decided and shipped — each answered its
+   own scope question once the code was in front of it, which is worth remembering the next time a
+   slice is held for a decision that only the implementation can inform.)*
 
 Ordering caveat: U-6 rewrites the block the status doc already wants extracted (item 11 — `ThreeDEditor.jsx` → `.tsx`, with `EditToolbar` split out of the ~250-line render). Doing U-6 as part of that extraction rather than before it avoids paying for the same surgery twice.
 
 ## 5. Questions for review
 
 1. **Is the status bar acceptable as permanent chrome?** It costs ~40 px of canvas height. The alternative is a corner overlay that appears on hover, which is less discoverable but takes no space. Recommendation: permanent, collapsible.
-2. ~~**U-12 and U-13 both hinge on the same scope question**~~ — **answered**; see the P2 table in §3. Figure export needs renderer internals a host cannot reach, so it lives here. Touch support turned out not to be a mobile port at all — the layout already fits at 390 px, measured — so "is mobile in scope" dissolved into "stop half-doing it"; it ships as a stacked follow-up PR.
+2. ~~**U-12 and U-13 both hinge on the same scope question**~~ — **answered**; see the P2 table in §3. Figure export needs renderer internals a host cannot reach, so it lives here. Touch support turned out not to be a mobile port at all — the layout already fits at 390 px, measured — so "is mobile in scope" dissolved into "stop half-doing it". It ships as a stacked PR for reviewability, not because the decision was still open.
 3. **Should the element chips be interactive** (click to select every atom of that element) or purely a legend? Interactive composes cleanly with the existing multi-select and costs little, but it puts a selection control in a status bar, which is unusual.
 4. **U-9 relaxes a deliberate guard.** `Ctrl/Cmd+Z` is currently edit-mode-only. Ungating it means the viewer swallows a key that an embedding host might want for its own undo — the ref API in spec §6.3 exists precisely so hosts can drive our stack instead. Worth confirming against materials-designer's expectations before changing.
 

--- a/plan/context/2026-08-12T20-25Z-uiux-implementation.md
+++ b/plan/context/2026-08-12T20-25Z-uiux-implementation.md
@@ -33,13 +33,12 @@ P0 and P1 — `U-1` through `U-11` — as one branch per item.
 | — | (tip) | `2e5fa89` | this context record |
 | — | (tip) | `19527bd` | retry `npm ci` (sharp/libvips 503) |
 | U-12 | `claude/uiux-p2-figure-export` | `e4fb816` | figure export |
+| U-13 | `claude/uiux-p2-touch-support` | `b7f01b2` | touch + small screens |
 
-Suite: **185 → 410 passing**, 28/28 suites, 0 failed. `tsc --noEmit` clean, `npm run lint` 0 errors.
+Suite: **185 → 440 passing**, 30/30 suites, 0 failed. `tsc --noEmit` clean, `npm run lint` 0 errors.
+**Every U-n is shipped.**
 
-**`U-13` (touch and small screens) is a separate PR stacked on this one**, on branch
-`claude/uiux-p2-touch-support`. It is the only item in the set that changes how *existing* input is
-handled rather than adding a surface, so it is worth being separately reviewable and separately
-revertable. Its own record is in §8.
+`U-13` sits in a **second PR stacked on #214** rather than in it — see §8 for why.
 
 ## 2. Decisions worth not relitigating
 
@@ -71,6 +70,14 @@ revertable. Its own record is in §8.
   a `try/finally` gets the same result with one context; what it costs is the discipline of restoring
   *everything* — size, pixel ratio, clear colour and alpha, scene background, fog, and every material
   colour touched — which is what the tests pin.
+- **`U-13` sizes by pointer capability, never by viewport width.** The `isMobile` it replaces asked
+  the wrong question in both directions. Sizing keys off `(pointer: coarse)`, documentation off
+  whether touch exists at all, and both are read at call time — a window can be dragged to a
+  touchscreen mid-session.
+- **`U-13` is not a mobile port and should not grow into one.** The existing chrome was *measured* at
+  390×844 and fits: no collisions, no clipping. The defects were gesture ownership, 32 px targets and
+  labels naming keys the device lacks. A bottom sheet would have been a rewrite in search of a
+  problem.
 
 ## 3. Confirmed *not* defects — do not re-investigate
 
@@ -136,7 +143,7 @@ that tolerance on its own evidence, not as a way to hide a stale reference.
 
 ## 6. What the browser pass caught that jsdom could not
 
-Six defects in newly written code, which is the argument for keeping a real-browser pass in the
+Nine defects in newly written code, which is the argument for keeping a real-browser pass in the
 loop rather than trusting the suite alone:
 
 1. The pill advertised `RMB = orbit` unconditionally while orbit starts disabled.
@@ -148,11 +155,18 @@ loop rather than trusting the suite alone:
 5. Slider range marks overlapped their caption, because MUI positions mark labels absolutely.
 6. `U-12`'s scale-bar label was set at `height/28` only after looking at a rendered figure; the
    original `height/36` is about 5 pt at 300 dpi, under most journals' minimum type size.
+7. The shortcut sheet still promised "? or Esc to close" on a touch profile with neither, and had no
+   visible way out at all (the exits were `?`, Escape, or knowing that the backdrop dismisses).
+8. The touch gesture group rendered *last*, below three groups of keyboard shortcuts, on the one
+   device where those gestures are the only way in — and the sheet is single-column there, so group
+   order is scroll distance.
+9. Probes that measured "the canvas" were measuring the 100×100 axes overlay, not the viewer.
 
-One pre-existing bug also came out of verification rather than reading: the orthographic projection
-matrix was never updated after the frustum was fitted to the cell. Caught by cross-checking the
-scale bar against the camera's own projection over a known 2 Å separation — the kind of assertion
-that catches a formula wrong by a constant factor, which nothing else in the suite would have.
+Two pre-existing bugs also came out of verification rather than reading (both fixed): the
+orthographic projection matrix never being updated after the frustum was fitted to the cell, and
+`touch-action: auto` swallowing every touch drag. The first was caught by cross-checking the scale
+bar against the camera's own projection over a known 2 Å separation — the kind of assertion that
+catches a formula wrong by a constant factor, which nothing else in the suite would have.
 
 ## 7. Deployment
 
@@ -167,18 +181,22 @@ Chromium in this container cannot traverse the sandbox's egress proxy (curl can)
 was verified by fetching it, not by driving it. The interactive verification was done against the
 byte-identical local build of the same artifact.
 
-## 8. The stacked touch PR (`U-13`)
+## 8. Why `U-13` is a stacked PR rather than more commits on #214
 
-Branch `claude/uiux-p2-touch-support`, based on this PR's head rather than on `dev`. Kept separate
-because it is the only item in the set that changes how *existing* input is handled — `touch-action`
-on the canvas and OrbitControls' touch mapping in edit mode — rather than adding a new surface. That
-makes it the one slice worth being able to review and revert on its own.
+Branch `claude/uiux-p2-touch-support`, based on #214's head rather than on `dev`.
 
-What it contains: `touch-action: none` on the renderer canvas (without which no touch drag ever
-reached any handler); edit mode reserving the first finger, mirroring how it already frees the left
-mouse button; `utils/inputCapabilities.ts` replacing the viewport-width `isMobile` with pointer
-capability queries; 44 px targets under `(pointer: coarse)`; and the shortcut sheet reachable without
-a keyboard, with a touch-gesture section and honest labels.
+Every other item in this set *adds* a surface: a status bar, a pill, a sheet, a dialog. If any of them
+is wrong, the blast radius is the thing it added. `U-13` is the exception — it changes how input the
+viewer already receives is handled: `touch-action: none` on the canvas takes gesture ownership away
+from the browser for anything drawn over that canvas, and the edit-mode `touches` remap changes what a
+one-finger drag does. Both are correct and tested, and both are the kind of change worth being able to
+revert by itself without unpicking eleven unrelated features. So it gets its own reviewable PR.
+
+The practical consequence to keep straight: the branch chain was previously fast-forwarded so #214's
+head carried *everything*, which made a PR between the two branches an empty diff. Splitting meant
+rewinding #214's head to the U-12 tip and replaying the U-13 commits on top of it. The lint fix stayed
+with #214 (it fixes U-12's own file and is what makes `verify` green) and the design-doc update was
+split in two, so #214 alone never claims U-13 shipped.
 
 ## 9. Open / next
 

--- a/src/components/KeyboardSheet.tsx
+++ b/src/components/KeyboardSheet.tsx
@@ -1,5 +1,7 @@
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Divider from "@mui/material/Divider";
@@ -7,6 +9,7 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
+import { hasCoarsePointer } from "../utils/inputCapabilities";
 import { getGroupedKeyBindings, getModifierLabel } from "../utils/keyBindings";
 
 /**
@@ -20,6 +23,16 @@ export interface KeyboardSheetProps {
     onClose?: () => void;
     /** Mirrors ThreeDEditor's prop: without it the edit bindings do not exist to advertise. */
     editable?: boolean;
+    /**
+     * Whether to list the touch gestures (U-13). Defaults to whether the device can produce touch
+     * input at all - see getKeyBindings - and is a prop so a test can assert both shapes.
+     */
+    includeTouch?: boolean;
+    /**
+     * Whether the primary pointer is coarse. Decides the group order (touch first where touch is how
+     * the viewer is driven) and suppresses the key-based close hint. A prop so a test can assert both.
+     */
+    isCoarsePointer?: boolean;
 }
 
 function KeyRow({ label, keys }: { label: string; keys: string }) {
@@ -44,8 +57,9 @@ function KeyRow({ label, keys }: { label: string; keys: string }) {
 }
 
 function KeyboardSheet(props: KeyboardSheetProps) {
-    const { isOpen = false, onClose, editable = true } = props;
-    const sections = getGroupedKeyBindings({ editable });
+    const { isOpen = false, onClose, editable = true, includeTouch, isCoarsePointer } = props;
+    const isCoarse = isCoarsePointer ?? hasCoarsePointer();
+    const sections = getGroupedKeyBindings({ editable, includeTouch, touchFirst: isCoarse });
 
     return (
         <Dialog
@@ -59,25 +73,38 @@ function KeyboardSheet(props: KeyboardSheetProps) {
             <DialogTitle id="keyboard-sheet-title" sx={{ pb: 1 }}>
                 <Stack direction="row" justifyContent="space-between" alignItems="baseline">
                     <Typography variant="h6" component="span">
-                        Keyboard shortcuts
+                        {/* Not "Keyboard shortcuts": the sheet has always listed pointer gestures
+                            too, and on a touch device the keyboard is the part that may not exist. */}
+                        Shortcuts &amp; gestures
                     </Typography>
-                    <Typography variant="caption" color="text.secondary">
-                        ? or Esc to close
-                    </Typography>
+                    {!isCoarse && (
+                        <Typography variant="caption" color="text.secondary">
+                            ? or Esc to close
+                        </Typography>
+                    )}
                 </Stack>
             </DialogTitle>
             <DialogContent>
-                <Stack
-                    direction={{ xs: "column", sm: "row" }}
-                    spacing={4}
-                    divider={<Divider orientation="vertical" flexItem />}
-                    alignItems="flex-start"
+                <Box
+                    sx={{
+                        display: "grid",
+                        // A grid rather than a row of columns: the touch group (U-13) makes four,
+                        // and four fixed columns crush the labels on the narrow screens that group
+                        // exists for. auto-fit reflows to one column on a phone by itself.
+                        gridTemplateColumns: {
+                            xs: "1fr",
+                            sm: "repeat(auto-fit, minmax(190px, 1fr))",
+                        },
+                        columnGap: 4,
+                        rowGap: 2.5,
+                        alignItems: "start",
+                    }}
                 >
                     {sections.map((section) => (
                         <Stack
                             key={section.group}
                             spacing={0.75}
-                            sx={{ flex: 1, minWidth: 0, width: "100%" }}
+                            sx={{ minWidth: 0, width: "100%" }}
                             data-name={`KeyboardSheetGroup-${section.group}`}
                         >
                             <Typography
@@ -97,12 +124,20 @@ function KeyboardSheet(props: KeyboardSheetProps) {
                             ))}
                         </Stack>
                     ))}
-                </Stack>
+                </Box>
                 <Divider sx={{ my: 2 }} />
                 <Typography variant="caption" color="text.secondary">
                     {`The modifier resolves per platform — Ctrl on Windows and Linux, Cmd on macOS; shown above as ${getModifierLabel()}. Edit mode and the measurement modes are mutually exclusive: arming a measurement leaves edit mode, and entering edit mode clears measurements.`}
                 </Typography>
             </DialogContent>
+            {/* An explicit Close, because the only way out used to be `?`, Escape, or knowing that
+                tapping the backdrop dismisses a dialog - none of which is available or discoverable
+                on a phone (U-13). */}
+            <DialogActions>
+                <Button onClick={onClose} data-name="KeyboardSheetClose">
+                    Close
+                </Button>
+            </DialogActions>
         </Dialog>
     );
 }

--- a/src/components/ModePill.tsx
+++ b/src/components/ModePill.tsx
@@ -9,6 +9,7 @@ import React from "react";
 import { MEASUREMENT_MODES_ENUM } from "../enums";
 import { MeasurementSettingsForType } from "../mixins/measurements/MeasurementSettingsHandler";
 import settings from "../settings";
+import { hasCoarsePointer } from "../utils/inputCapabilities";
 import {
     formatMeasurementValue,
     getMeasurementHint,
@@ -71,28 +72,44 @@ export interface ModePillProps {
 /**
  * Bindings worth stating in the pill, sourced from settings so a rebind cannot desync them.
  *
- * `isOrbitEnabled` gates the right-button note. Orbit controls start disabled
+ * `isOrbitEnabled` gates the orbit note. Orbit controls start disabled
  * (`initOrbitControls(enabled = false)`), so while they are off the right button orbits nothing -
  * and advertising a binding that does nothing is the defect this whole slice is trying to undo.
+ *
+ * `isCoarsePointer` decides *which* orbit gesture is named. A phone has no right button, and edit
+ * mode reserves one finger for atoms exactly as it frees the left button, so there the camera is on
+ * two fingers (U-13). Naming the mouse binding on a touch device would be the same class of lie.
  */
 export function getEditModeBindings({
     isOrbitEnabled = false,
-}: { isOrbitEnabled?: boolean } = {}): string[] {
+    isCoarsePointer = hasCoarsePointer(),
+}: { isOrbitEnabled?: boolean; isCoarsePointer?: boolean } = {}): string[] {
     const keys = settings.hotKeysConfig as Record<string, string>;
     const orbitKey = keys?.toggleOrbitControls?.toUpperCase();
     // The remap that surprises people: in edit mode a left-drag on empty space marquees, so orbit
-    // moves to the right button (D-4). That is only true once orbit is on, so while it is off the
-    // pill points at the key that turns it on instead of naming a button that does nothing.
+    // moves to the right button (D-4) - or to two fingers on touch. That is only true once orbit is
+    // on, so while it is off the pill points at the way to turn it on instead.
     let orbitNote = "";
-    if (isOrbitEnabled) orbitNote = "RMB = orbit";
+    if (isOrbitEnabled) orbitNote = isCoarsePointer ? "2 fingers = orbit" : "RMB = orbit";
+    else if (isCoarsePointer) orbitNote = "Rotate/Zoom off";
     else if (orbitKey) orbitNote = `${orbitKey} = enable orbit`;
 
+    // Keyboard rows are dropped on a coarse pointer: Del and Esc name keys a phone does not have,
+    // and the toolbar's Remove button is the reachable equivalent.
+    const keyboardNotes = isCoarsePointer
+        ? []
+        : [
+              "Del = remove",
+              "Esc = deselect",
+              keys?.focusCameraOnSelection
+                  ? `${keys.focusCameraOnSelection.toUpperCase()} = focus`
+                  : "",
+          ];
+
     return [
-        "drag = move",
+        isCoarsePointer ? "drag atom = move" : "drag = move",
         orbitNote,
-        "Del = remove",
-        "Esc = deselect",
-        keys?.focusCameraOnSelection ? `${keys.focusCameraOnSelection.toUpperCase()} = focus` : "",
+        ...keyboardNotes,
     ].filter(Boolean);
 }
 
@@ -196,8 +213,8 @@ function ModePill(props: ModePillProps) {
                 position: "absolute",
                 top: "1em",
                 // Insets clear the chrome pinned to either edge - the icon strip on the left, the edit
-                // toolbar on the right. Spanning the full width let the pill grow to 520 px and run
-                // underneath both of them, which is what an embedded viewer showed first.
+                // toolbar and inspector on the right. Spanning the full width let the pill grow to
+                // 520 px and run underneath all of them, which an embedded viewer showed first.
                 left: SIDE_CHROME_INSET,
                 right: isEditModeActive ? EDIT_SURFACE_INSET : SIDE_CHROME_INSET,
                 // The canvas keeps its pointer events; each pill opts back in for itself.
@@ -238,9 +255,9 @@ function ModePill(props: ModePillProps) {
                         activeMeasurement.measurementType,
                     ).toLowerCase()} mode`}
                 >
-                    {/* The measurement hint says what to click next, which is the whole point of the
-                        pill in a mode armed from a menu that closed - so it is kept and truncated
-                        rather than dropped. */}
+                    {/* The measurement hint says what to click next, which is the whole point of
+                        the pill in a mode armed from a menu that closed - so it is kept and
+                        truncated rather than dropped. */}
                     <Typography
                         variant="caption"
                         noWrap

--- a/src/components/QuickToggles.tsx
+++ b/src/components/QuickToggles.tsx
@@ -4,6 +4,8 @@ import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
 import React from "react";
 
+import { COARSE_POINTER_QUERY, TOUCH_TARGET_MIN_PX } from "../utils/inputCapabilities";
+
 /**
  * The handful of view toggles worth reaching in one click.
  *
@@ -86,6 +88,16 @@ function QuickToggles({ items = [] }: QuickTogglesProps) {
                                     height: 32,
                                     p: 0,
                                     borderRadius: "16px",
+                                    // Grown to the touch minimum on coarse pointers only (U-13): a
+                                    // 32 px circle is a comfortable mouse target and an unreliable
+                                    // finger one, and this row is the primary control surface on a
+                                    // phone, where the toolbar menus are the awkward path.
+                                    [`@media ${COARSE_POINTER_QUERY}`]: {
+                                        width: TOUCH_TARGET_MIN_PX,
+                                        height: TOUCH_TARGET_MIN_PX,
+                                        borderRadius: `${TOUCH_TARGET_MIN_PX / 2}px`,
+                                        "& svg": { fontSize: "1.35rem" },
+                                    },
                                     cursor: "pointer",
                                     border: 1,
                                     borderColor: item.isActive ? "primary.light" : "divider",

--- a/src/components/ThreeDEditor.jsx
+++ b/src/components/ThreeDEditor.jsx
@@ -17,6 +17,7 @@ import Edit from "@mui/icons-material/Edit";
 import FormatShapes from "@mui/icons-material/FormatShapes";
 import GpsFixed from "@mui/icons-material/GpsFixed";
 import HeightIcon from "@mui/icons-material/Height";
+import HelpOutline from "@mui/icons-material/HelpOutline";
 import Image from "@mui/icons-material/Image";
 import ImportExport from "@mui/icons-material/ImportExport";
 import LooksIcon from "@mui/icons-material/Looks";
@@ -1318,6 +1319,20 @@ export class ThreeDEditor extends React.Component {
                 leftIcon: <Replay />,
                 onClick: this.handleResetViewer,
                 shouldMenuStayOpened: true,
+            },
+            {
+                id: "divider-help",
+                isDivider: true,
+            },
+            {
+                // The sheet was reachable only by pressing `?` (U-3), which is unreachable on a
+                // device with no keyboard - so the one surface documenting how to drive the viewer
+                // was missing exactly where a user most needs it (U-13). The key still works.
+                id: "keyboard-sheet",
+                disabled: false,
+                content: "Shortcuts & gestures",
+                leftIcon: <HelpOutline />,
+                onClick: this.handleToggleKeyboardSheet,
             },
         ];
     };

--- a/src/mixins/interactive_structure_editor.ts
+++ b/src/mixins/interactive_structure_editor.ts
@@ -11,6 +11,16 @@ const HIGHLIGHT_SCALE_FACTOR = 1.25;
 const DRAG_COMMIT_EPSILON = 1e-6;
 
 /**
+ * Value put in OrbitControls' `touches.ONE` while edit mode owns the first finger (U-13).
+ *
+ * OrbitControls has no "no gesture" constant for touch the way `mouseButtons` accepts null: its
+ * `onTouchStart` switches on `touches.ONE` over TOUCH.ROTATE and TOUCH.PAN and falls through to
+ * `STATE.NONE` for anything else. Deliberately outside the enum (TOUCH runs 0-3), and named so the
+ * next reader does not "fix" it into a real gesture.
+ */
+const ONE_FINGER_RESERVED_FOR_EDITING = -1;
+
+/**
  * Mixin providing interactive structure editing capabilities inside the Wave visualizer.
  * Enforces strict object-oriented design and follows the "6 months x 3 beers" rule for comments.
  */
@@ -56,6 +66,8 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
 
         orbitControlsDefaultMouseButtons_: any | null;
 
+        orbitControlsDefaultTouches_: any | null;
+
         lastSelectedAtomicIndices_: number[] | null;
 
         handlePointerDownCapture_: ((event: PointerEvent) => void) | null;
@@ -91,6 +103,7 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
             this.activePointerId_ = null;
             this.orbitControlsEnabledBeforeDrag_ = true;
             this.orbitControlsDefaultMouseButtons_ = null;
+            this.orbitControlsDefaultTouches_ = null;
             this.lastSelectedAtomicIndices_ = null;
             this.handlePointerDownCapture_ = null;
             this.handlePointerMoveCapture_ = null;
@@ -791,6 +804,12 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
          * OrbitControls left mouse button off (freeing it for marquee-select on empty space) and
          * moves camera rotation onto the right mouse button (decision D-4); the defaults are
          * restored on disable.
+         *
+         * Touch gets the same treatment for the same reason (U-13). OrbitControls' default
+         * `touches.ONE` is ROTATE, which is the finger the editor needs for selecting, dragging an
+         * atom and marquee-selecting - so while edit mode is on, one finger belongs to the editor and
+         * the camera moves to two fingers (DOLLY_ROTATE: pinch to zoom, twist to orbit). There is no
+         * right button to move it to.
          * @param {boolean} enabled - True to enable, false to disable.
          */
         enableEditMode(enabled: boolean): void {
@@ -803,9 +822,24 @@ export const InteractiveStructureEditorMixin = (superclass: any) =>
                         LEFT: null,
                         RIGHT: THREE.MOUSE.ROTATE,
                     };
-                } else if (this.orbitControlsDefaultMouseButtons_) {
-                    this.orbitControls.mouseButtons = this.orbitControlsDefaultMouseButtons_;
-                    this.orbitControlsDefaultMouseButtons_ = null;
+                    this.orbitControlsDefaultTouches_ = { ...this.orbitControls.touches };
+                    this.orbitControls.touches = {
+                        // OrbitControls switches on `touches.ONE` and falls through to STATE.NONE
+                        // for anything it does not recognise, which is how a one-finger gesture is
+                        // handed to the editor - the same "no camera on this input" intent as
+                        // LEFT: null above, expressed the only way the touch path allows.
+                        ONE: ONE_FINGER_RESERVED_FOR_EDITING,
+                        TWO: THREE.TOUCH.DOLLY_ROTATE,
+                    };
+                } else {
+                    if (this.orbitControlsDefaultMouseButtons_) {
+                        this.orbitControls.mouseButtons = this.orbitControlsDefaultMouseButtons_;
+                        this.orbitControlsDefaultMouseButtons_ = null;
+                    }
+                    if (this.orbitControlsDefaultTouches_) {
+                        this.orbitControls.touches = this.orbitControlsDefaultTouches_;
+                        this.orbitControlsDefaultTouches_ = null;
+                    }
                 }
             }
 

--- a/src/utils/inputCapabilities.ts
+++ b/src/utils/inputCapabilities.ts
@@ -1,0 +1,70 @@
+/**
+ * What kind of pointer is driving the viewer (U-13).
+ *
+ * `IconsToolbar` computed `isMobile` from `theme.breakpoints.down("sm")` and forwarded it to exactly
+ * one dropdown; nothing else in the viewer adapted. That is the half-support the proposal called the
+ * worst of the three options, and it asked the wrong question twice over: a narrow browser window on
+ * a desktop is not touch input, and a 13-inch touch laptop is, at any width. What actually decides
+ * whether a 32 px control is reachable, whether a hover tooltip can ever be seen, and whether "right
+ * button" names anything real is the *pointer*, not the viewport.
+ *
+ * So capability queries, read at call time rather than at module load, because a window can move to
+ * another display and a tablet can gain a keyboard mid-session.
+ */
+
+/** Devices whose primary pointer has coarse accuracy: fingers, and styluses without hover. */
+export const COARSE_POINTER_QUERY = "(pointer: coarse)";
+
+/** Devices that cannot hover, so anything living only in a tooltip is unreachable. */
+export const NO_HOVER_QUERY = "(hover: none)";
+
+/**
+ * Minimum comfortable touch target. 44 px is the long-standing platform guidance (WCAG 2.2's
+ * Target Size (Minimum) sets 24 px as the floor; 44 is what a finger actually wants).
+ */
+export const TOUCH_TARGET_MIN_PX = 44;
+
+function matches(query: string): boolean {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+    try {
+        return window.matchMedia(query).matches;
+    } catch (error) {
+        // jsdom and some embedded webviews implement matchMedia partially; an unsupported query
+        // should read as "not coarse" rather than take the viewer down.
+        return false;
+    }
+}
+
+export function hasCoarsePointer(): boolean {
+    return matches(COARSE_POINTER_QUERY);
+}
+
+export function hasNoHover(): boolean {
+    return matches(NO_HOVER_QUERY);
+}
+
+/**
+ * Whether the device can produce touch input at all - which is not the same question as whether the
+ * *primary* pointer is coarse. A touch laptop reports a fine primary pointer and still needs the
+ * touch gestures documented, so this is what gates the gesture list while `hasCoarsePointer` gates
+ * sizing.
+ */
+export function hasTouchSupport(): boolean {
+    if (typeof navigator !== "undefined" && typeof navigator.maxTouchPoints === "number") {
+        return navigator.maxTouchPoints > 0;
+    }
+    if (typeof window !== "undefined" && "ontouchstart" in window) return true;
+    return hasCoarsePointer();
+}
+
+/**
+ * `sx` fragment enlarging a control to the touch minimum on coarse pointers only, so a mouse-driven
+ * viewer keeps its compact chrome. Applied as a media query rather than a breakpoint for the reason
+ * in the module comment.
+ */
+export const coarsePointerTargetSx = {
+    [`@media ${COARSE_POINTER_QUERY}`]: {
+        minWidth: `${TOUCH_TARGET_MIN_PX}px`,
+        minHeight: `${TOUCH_TARGET_MIN_PX}px`,
+    },
+};

--- a/src/utils/keyBindings.ts
+++ b/src/utils/keyBindings.ts
@@ -1,4 +1,5 @@
 import settings from "../settings";
+import { hasTouchSupport } from "./inputCapabilities";
 
 /**
  * One source of truth for what the viewer's keys and pointer gestures do.
@@ -12,7 +13,7 @@ import settings from "../settings";
  * that promised a hotkey which did not exist - was the same drift running the other way.
  */
 
-export type BindingGroup = "view" | "edit" | "measure";
+export type BindingGroup = "view" | "edit" | "measure" | "touch";
 
 export interface KeyBinding {
     /** What the binding does, in the user's terms. */
@@ -22,6 +23,12 @@ export interface KeyBinding {
     group: BindingGroup;
     /** A pointer gesture rather than a key - grouped the same, rendered the same. */
     isGesture?: boolean;
+    /**
+     * Only meaningful in edit mode. The mouse gestures express this through `group: "edit"`, but the
+     * touch rows are grouped by input device instead, so they carry it explicitly - filtering them by
+     * matching label text would break silently the first time a label is reworded.
+     */
+    editOnly?: boolean;
 }
 
 export interface EditorKeyDefinition {
@@ -83,6 +90,41 @@ const POINTER_GESTURES: KeyBinding[] = [
     { label: "Move atom / group", keys: "drag atom", group: "edit", isGesture: true },
 ];
 
+/**
+ * Touch gestures (U-13). Listed separately because they are not alternative labels for the mouse
+ * gestures above - the mapping genuinely differs. In edit mode one finger is reserved for atoms, the
+ * same way the left button is (decision D-4), so orbiting moves to two fingers rather than the right
+ * button, which touch does not have.
+ *
+ * Every row here has to be true of the running build: this list existing at all is only an
+ * improvement if a user who follows it gets the result it promises.
+ */
+const TOUCH_GESTURES: KeyBinding[] = [
+    {
+        label: "Rotate (once Rotate/Zoom is on)",
+        keys: "one-finger drag",
+        group: "touch",
+        isGesture: true,
+    },
+    { label: "Zoom", keys: "pinch", group: "touch", isGesture: true },
+    { label: "Pan", keys: "two-finger drag", group: "touch", isGesture: true },
+    { label: "Select atom", keys: "tap", group: "touch", isGesture: true, editOnly: true },
+    {
+        label: "Move atom / group",
+        keys: "drag atom",
+        group: "touch",
+        isGesture: true,
+        editOnly: true,
+    },
+    {
+        label: "Orbit while editing",
+        keys: "two fingers",
+        group: "touch",
+        isGesture: true,
+        editOnly: true,
+    },
+];
+
 /** Configured single-character keys, in the order they should read, with their group. */
 const HOTKEY_ROWS: { setting: string; label: string; group: BindingGroup }[] = [
     { setting: "toggleInteractive", label: "Interactive on / off", group: "view" },
@@ -112,13 +154,23 @@ export const BINDING_GROUP_LABELS: Record<BindingGroup, string> = {
     view: "View & camera",
     edit: "Select & edit",
     measure: "Measure",
+    touch: "Touch",
 };
 
 /**
  * Every binding, grouped. `editable` mirrors the component prop: without it there is no edit mode,
  * so advertising its keys would promise something the viewer will not do.
+ *
+ * `includeTouch` defaults to whether the device can produce touch input at all, rather than to
+ * whether the primary pointer is coarse: a touch laptop drives the viewer with a trackpad and still
+ * needs the gestures documented. Keyboard rows stay visible either way - a tablet with a keyboard is
+ * an ordinary configuration, and hiding them would be the mirror image of the F3 discoverability
+ * problem this file exists to fix.
  */
-export function getKeyBindings({ editable = true }: { editable?: boolean } = {}): KeyBinding[] {
+export function getKeyBindings({
+    editable = true,
+    includeTouch,
+}: { editable?: boolean; includeTouch?: boolean } = {}): KeyBinding[] {
     const hotKeys = settings.hotKeysConfig as Record<string, string | undefined>;
     const editorKeys = settings.editorKeysConfig as Record<string, EditorKeyDefinition | undefined>;
 
@@ -148,15 +200,30 @@ export function getKeyBindings({ editable = true }: { editable?: boolean } = {})
         ? POINTER_GESTURES
         : POINTER_GESTURES.filter((gesture) => gesture.group !== "edit");
 
-    return [...fromHotKeys, ...fromEditorKeys, ...gestures];
+    const showTouch = includeTouch ?? hasTouchSupport();
+    const touchGestures = showTouch
+        ? TOUCH_GESTURES.filter((gesture) => editable || !gesture.editOnly)
+        : [];
+
+    return [...fromHotKeys, ...fromEditorKeys, ...gestures, ...touchGestures];
 }
 
-/** The same bindings bucketed by group, skipping groups that came out empty. */
+/**
+ * The same bindings bucketed by group, skipping groups that came out empty.
+ *
+ * `touchFirst` moves the touch group to the front. On a phone the sheet reflows to a single column,
+ * so a group's position is how far the user has to scroll to reach it - and putting the gestures that
+ * are the only way to drive that device below three groups of keyboard shortcuts buries the one
+ * section they came for.
+ */
 export function getGroupedKeyBindings(
-    options: { editable?: boolean } = {},
+    options: { editable?: boolean; includeTouch?: boolean; touchFirst?: boolean } = {},
 ): { group: BindingGroup; label: string; bindings: KeyBinding[] }[] {
     const all = getKeyBindings(options);
-    return (["view", "edit", "measure"] as BindingGroup[])
+    const order: BindingGroup[] = options.touchFirst
+        ? ["touch", "view", "edit", "measure"]
+        : ["view", "edit", "measure", "touch"];
+    return order
         .map((group) => ({
             group,
             label: BINDING_GROUP_LABELS[group],

--- a/src/wave.js
+++ b/src/wave.js
@@ -87,6 +87,12 @@ class WaveBase {
         this.renderer.sortObjects = false;
         this.renderer.domElement.style.width = "100%";
         this.renderer.domElement.style.height = "100%";
+        // Without this the browser claims touch drags for scrolling and pinch-zooming the page, and
+        // sends `pointercancel` to everything that had started tracking the gesture - so on a phone
+        // or a touch laptop no drag ever reached the viewer: not orbiting, not dragging an atom, not
+        // marquee-selecting (U-13). Every pointer handler in the editor is already pointer-event
+        // based, so this one declaration is what makes them work with a finger.
+        this.renderer.domElement.style.touchAction = "none";
         this.container.appendChild(this.renderer.domElement);
         this.renderer.setSize(this.WIDTH, this.HEIGHT);
         // Observes the container itself (not the window) so resizing works correctly when the

--- a/tests/__tests__/touchSupport.jsx
+++ b/tests/__tests__/touchSupport.jsx
@@ -1,0 +1,203 @@
+import Adapter from "@wojtekmaj/enzyme-adapter-react-17";
+import Enzyme from "enzyme";
+import expect from "expect";
+import React from "react";
+import * as THREE from "three";
+
+import KeyboardSheet from "../../src/components/KeyboardSheet";
+import { getEditModeBindings } from "../../src/components/ModePill";
+import { getGroupedKeyBindings, getKeyBindings } from "../../src/utils/keyBindings";
+import { getWaveInstance } from "../enums";
+
+Enzyme.configure({ adapter: new Adapter() });
+
+const { mount } = Enzyme;
+
+/**
+ * Touch and small-screen support (U-13).
+ *
+ * The proposal's position was that half-support is the worst of the three options, and the viewer was
+ * squarely in it: `isMobile` was computed from the viewport width and forwarded to one dropdown, the
+ * canvas let the browser eat every touch drag, and the only place documenting how to drive the viewer
+ * needed a keyboard to open. These are the assertions that the half is closed.
+ */
+describe("touch support", () => {
+    describe("canvas gesture ownership", () => {
+        it("claims touch gestures from the browser", () => {
+            // Without touch-action: none the browser treats a drag as page scroll or pinch-zoom and
+            // sends pointercancel to the viewer - so no touch drag ever reached orbit, atom dragging
+            // or marquee select, whatever the handlers did.
+            const wave = getWaveInstance();
+            expect(wave.renderer.domElement.style.touchAction).toBe("none");
+        });
+    });
+
+    describe("edit mode reserves the first finger", () => {
+        let wave;
+
+        beforeEach(() => {
+            wave = getWaveInstance();
+            if (!wave.orbitControls) wave.initOrbitControls(true);
+        });
+
+        it("moves the camera to two fingers while editing, as it moves it to the right button", () => {
+            const defaults = { ...wave.orbitControls.touches };
+            expect(defaults.ONE).toBe(THREE.TOUCH.ROTATE);
+
+            wave.enableEditMode(true);
+
+            // One finger belongs to select / drag-atom / marquee; anything OrbitControls does not
+            // recognise leaves it in STATE.NONE, which is how "no camera on this input" is said.
+            expect([THREE.TOUCH.ROTATE, THREE.TOUCH.PAN]).not.toContain(
+                wave.orbitControls.touches.ONE,
+            );
+            expect(wave.orbitControls.touches.TWO).toBe(THREE.TOUCH.DOLLY_ROTATE);
+        });
+
+        it("restores the touch mapping on leaving edit mode", () => {
+            const defaults = { ...wave.orbitControls.touches };
+            wave.enableEditMode(true);
+            wave.enableEditMode(false);
+            expect(wave.orbitControls.touches).toEqual(defaults);
+        });
+
+        it("restores it after repeated entry and exit, not just the first round trip", () => {
+            const touchDefaults = { ...wave.orbitControls.touches };
+            const buttonDefaults = { ...wave.orbitControls.mouseButtons };
+            for (let i = 0; i < 3; i += 1) {
+                wave.enableEditMode(true);
+                wave.enableEditMode(false);
+            }
+            expect(wave.orbitControls.touches).toEqual(touchDefaults);
+            expect(wave.orbitControls.mouseButtons).toEqual(buttonDefaults);
+        });
+
+        it("keeps the mouse remap it already had", () => {
+            wave.enableEditMode(true);
+            expect(wave.orbitControls.mouseButtons.LEFT).toBeNull();
+            expect(wave.orbitControls.mouseButtons.RIGHT).toBe(THREE.MOUSE.ROTATE);
+        });
+    });
+
+    describe("the shortcut sheet documents gestures that exist", () => {
+        it("lists touch gestures only where touch input is possible", () => {
+            const withTouch = getKeyBindings({ includeTouch: true });
+            const withoutTouch = getKeyBindings({ includeTouch: false });
+            expect(withTouch.some((binding) => binding.group === "touch")).toBe(true);
+            expect(withoutTouch.some((binding) => binding.group === "touch")).toBe(false);
+        });
+
+        it("names two fingers for orbiting, matching what edit mode actually does", () => {
+            const touch = getKeyBindings({ includeTouch: true }).filter((b) => b.group === "touch");
+            const orbit = touch.find((binding) => binding.label === "Orbit while editing");
+            expect(orbit.keys).toBe("two fingers");
+            // The mouse row for the same action still says right-drag: the mappings differ, which is
+            // why these are separate rows rather than one row with two labels.
+            const mouseOrbit = getKeyBindings()
+                .filter((b) => b.group === "edit")
+                .find((binding) => binding.label === "Orbit while editing");
+            expect(mouseOrbit.keys).toBe("right-drag");
+        });
+
+        it("drops the edit-only gestures when the viewer is not editable", () => {
+            const readOnly = getKeyBindings({ includeTouch: true, editable: false }).filter(
+                (b) => b.group === "touch",
+            );
+            expect(readOnly.map((binding) => binding.label)).toEqual(["Rotate (once Rotate/Zoom is on)", "Zoom", "Pan"]);
+        });
+
+        it("groups touch last on a mouse, where it is a supplement", () => {
+            const groups = getGroupedKeyBindings({ includeTouch: true }).map((s) => s.group);
+            expect(groups[groups.length - 1]).toBe("touch");
+        });
+
+        it("groups touch first on a coarse pointer, where it is the only way in", () => {
+            // On a phone the sheet is one column, so group order is scroll distance: three groups of
+            // keyboard shortcuts above the gestures buries the section the device actually needs.
+            const groups = getGroupedKeyBindings({ includeTouch: true, touchFirst: true }).map(
+                (s) => s.group,
+            );
+            expect(groups[0]).toBe("touch");
+        });
+
+        it("omits the touch group entirely rather than showing an empty column", () => {
+            const groups = getGroupedKeyBindings({ includeTouch: false }).map((s) => s.group);
+            expect(groups).not.toContain("touch");
+        });
+
+        it("renders the touch section in the sheet", () => {
+            const wrapper = mount(<KeyboardSheet isOpen includeTouch />);
+            expect(wrapper.find('[data-name="KeyboardSheetGroup-touch"]').exists()).toBe(true);
+            expect(wrapper.text()).toContain("pinch");
+        });
+
+        it("keeps the keyboard sections on a touch device", () => {
+            // A tablet with a keyboard is ordinary; hiding the key rows would be the same
+            // discoverability failure this sheet exists to fix, running the other way.
+            const wrapper = mount(<KeyboardSheet isOpen includeTouch />);
+            expect(wrapper.find('[data-name="KeyboardSheetGroup-view"]').exists()).toBe(true);
+            expect(wrapper.find('[data-name="KeyboardSheetGroup-edit"]').exists()).toBe(true);
+        });
+
+        it("offers a Close button, the only exit that needs no keyboard", () => {
+            const onClose = jest.fn();
+            const wrapper = mount(<KeyboardSheet isOpen onClose={onClose} isCoarsePointer />);
+            wrapper.find('button[data-name="KeyboardSheetClose"]').at(0).simulate("click");
+            expect(onClose).toHaveBeenCalled();
+        });
+
+        it("stops promising `?` and Escape on a device with neither", () => {
+            const coarse = mount(<KeyboardSheet isOpen includeTouch isCoarsePointer />);
+            expect(coarse.text()).not.toContain("Esc to close");
+            const fine = mount(<KeyboardSheet isOpen isCoarsePointer={false} />);
+            expect(fine.text()).toContain("Esc to close");
+        });
+
+        it("is titled for what it lists, not for the keyboard alone", () => {
+            const wrapper = mount(<KeyboardSheet isOpen includeTouch />);
+            expect(wrapper.text()).toContain("Shortcuts & gestures");
+        });
+
+        it("puts the touch section first when the pointer is coarse", () => {
+            const wrapper = mount(<KeyboardSheet isOpen includeTouch isCoarsePointer />);
+            const groups = wrapper
+                .find('[data-name^="KeyboardSheetGroup-"]')
+                .map((node) => node.prop("data-name"));
+            expect(groups[0]).toBe("KeyboardSheetGroup-touch");
+        });
+    });
+
+    describe("the mode pill names gestures the device has", () => {
+        it("names two fingers, not the right button, on a coarse pointer", () => {
+            const coarse = getEditModeBindings({ isOrbitEnabled: true, isCoarsePointer: true });
+            expect(coarse.join(" ")).toContain("2 fingers = orbit");
+            expect(coarse.join(" ")).not.toContain("RMB");
+        });
+
+        it("still names the right button for a mouse", () => {
+            const fine = getEditModeBindings({ isOrbitEnabled: true, isCoarsePointer: false });
+            expect(fine.join(" ")).toContain("RMB = orbit");
+            expect(fine.join(" ")).not.toContain("finger");
+        });
+
+        it("drops key names a phone cannot produce", () => {
+            const coarse = getEditModeBindings({ isOrbitEnabled: true, isCoarsePointer: true });
+            expect(coarse.join(" ")).not.toMatch(/Del|Esc/);
+            const fine = getEditModeBindings({ isOrbitEnabled: true, isCoarsePointer: false });
+            expect(fine.join(" ")).toContain("Del = remove");
+        });
+
+        it("says orbit is off rather than pointing at a key, on a coarse pointer", () => {
+            // The keyboard route to enabling orbit is useless without a keyboard; the View menu and
+            // the quick-toggle row are the reachable ones, and both are on screen.
+            const coarse = getEditModeBindings({ isOrbitEnabled: false, isCoarsePointer: true });
+            expect(coarse.join(" ")).toContain("Rotate/Zoom off");
+            expect(coarse.join(" ")).not.toMatch(/= enable orbit/);
+        });
+
+        it("defaults its answer from the device rather than requiring the caller to know", () => {
+            // jsdom reports a fine pointer, so the default must be the mouse wording.
+            expect(getEditModeBindings({ isOrbitEnabled: true }).join(" ")).toContain("RMB");
+        });
+    });
+});

--- a/tests/__tests__/utils/inputCapabilities.js
+++ b/tests/__tests__/utils/inputCapabilities.js
@@ -1,0 +1,105 @@
+import expect from "expect";
+
+import {
+    COARSE_POINTER_QUERY,
+    hasCoarsePointer,
+    hasNoHover,
+    hasTouchSupport,
+    NO_HOVER_QUERY,
+    TOUCH_TARGET_MIN_PX,
+} from "../../../src/utils/inputCapabilities";
+
+/**
+ * Input capability queries (U-13). These decide whether a control is reachable with a finger and
+ * whether the viewer is allowed to say "right button", so the interesting cases are the hostile
+ * environments: no matchMedia, a matchMedia that throws, and a device that reports touch without a
+ * coarse primary pointer.
+ */
+describe("inputCapabilities", () => {
+    const originalMatchMedia = window.matchMedia;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(navigator, "maxTouchPoints");
+
+    const setMatchMedia = (implementation) => {
+        Object.defineProperty(window, "matchMedia", {
+            value: implementation,
+            configurable: true,
+            writable: true,
+        });
+    };
+
+    const setMaxTouchPoints = (value) => {
+        Object.defineProperty(navigator, "maxTouchPoints", { value, configurable: true });
+    };
+
+    afterEach(() => {
+        setMatchMedia(originalMatchMedia);
+        if (originalDescriptor) {
+            Object.defineProperty(navigator, "maxTouchPoints", originalDescriptor);
+        } else {
+            delete navigator.maxTouchPoints;
+        }
+    });
+
+    it("reports the queries the media layer reports", () => {
+        setMatchMedia((query) => ({ matches: query === COARSE_POINTER_QUERY }));
+        expect(hasCoarsePointer()).toBe(true);
+        expect(hasNoHover()).toBe(false);
+
+        setMatchMedia((query) => ({ matches: query === NO_HOVER_QUERY }));
+        expect(hasCoarsePointer()).toBe(false);
+        expect(hasNoHover()).toBe(true);
+    });
+
+    it("reads the media layer at call time, not at module load", () => {
+        // A window can be dragged to a touchscreen and a tablet can gain a keyboard mid-session;
+        // caching the answer at import would freeze the viewer's chrome to whatever was true first.
+        setMatchMedia(() => ({ matches: false }));
+        expect(hasCoarsePointer()).toBe(false);
+        setMatchMedia(() => ({ matches: true }));
+        expect(hasCoarsePointer()).toBe(true);
+    });
+
+    it("answers 'not coarse' where matchMedia is missing", () => {
+        setMatchMedia(undefined);
+        expect(hasCoarsePointer()).toBe(false);
+        expect(hasNoHover()).toBe(false);
+    });
+
+    it("answers 'not coarse' rather than throwing when matchMedia rejects the query", () => {
+        // Some embedded webviews implement matchMedia partially; the viewer must not go down over a
+        // question about hit-target sizing.
+        setMatchMedia(() => {
+            throw new Error("unsupported media feature");
+        });
+        expect(hasCoarsePointer()).toBe(false);
+    });
+
+    describe("hasTouchSupport", () => {
+        it("trusts maxTouchPoints when the browser reports it", () => {
+            setMatchMedia(() => ({ matches: false }));
+            setMaxTouchPoints(5);
+            expect(hasTouchSupport()).toBe(true);
+            setMaxTouchPoints(0);
+            expect(hasTouchSupport()).toBe(false);
+        });
+
+        it("is true for a touch laptop, whose primary pointer is still fine", () => {
+            // The distinction the module exists to make: this device needs the touch gestures
+            // documented but should keep its compact, mouse-sized chrome.
+            setMatchMedia(() => ({ matches: false }));
+            setMaxTouchPoints(10);
+            expect(hasTouchSupport()).toBe(true);
+            expect(hasCoarsePointer()).toBe(false);
+        });
+
+        it("falls back to the coarse-pointer query when touch points are unreported", () => {
+            delete navigator.maxTouchPoints;
+            setMatchMedia((query) => ({ matches: query === COARSE_POINTER_QUERY }));
+            expect(hasTouchSupport()).toBe(true);
+        });
+    });
+
+    it("sets the touch target floor at the platform guidance figure", () => {
+        expect(TOUCH_TARGET_MIN_PX).toBe(44);
+    });
+});


### PR DESCRIPTION
**Stacked on `claude/uiux-p2-figure-export`** — review that one first; this PR's diff is U-13 only.

Touch and small-screen support, the last item of the UI/UX proposal (`docs/design/uiux-improvements-2026-08.md`, U-13). Kept separate because it is the only item in the set that changes how input the viewer *already receives* is handled, rather than adding a surface — so it is worth being reviewable, and revertable, on its own.

## What was actually wrong

Measured on a 390×844 touch profile before changing anything:

- **The canvas had `touch-action: auto`**, so the browser claimed every touch drag for page scroll and pinch-zoom and sent `pointercancel` to whatever had begun tracking it. **No touch drag ever reached any handler** — not orbiting, not moving an atom, not marquee select — even though every pointer handler in the editor is already pointer-event based. A one-finger swipe left the rendered frame byte-identical.
- **The quick-toggle row was 32 px**, and it is the primary control surface on a phone.
- **The only surface documenting how to drive the viewer opened on `?` alone** — unreachable without a keyboard.
- **`isMobile` was computed from the viewport width** and forwarded to exactly one dropdown. That is also the wrong question twice over: a narrow window on a desktop is not touch input, and a touch laptop is touch input at any width.

## Changes

- **`touch-action: none` on the renderer canvas.** One declaration, and every existing pointer handler starts working with a finger.
- **Edit mode reserves the first finger**, mirroring what it already does with the left mouse button (D-4): `touches.ONE` comes off the camera and orbit moves to two fingers (`DOLLY_ROTATE`). There is no right button to move it to. Restored on exit, verified across repeated round trips.
- **`utils/inputCapabilities.ts`** replaces the viewport guess with capability queries read at call time — a window can move to another display and a tablet can gain a keyboard mid-session. `hasCoarsePointer` gates sizing; `hasTouchSupport` gates documentation, so a touch laptop gets the gestures listed and keeps its compact chrome.
- **Quick toggles reach 44 px under `(pointer: coarse)` only.**
- **The shortcut sheet is reachable from View ▸ Shortcuts & gestures**, gains a visible Close, lists the touch gestures, and puts them *first* when the pointer is coarse — the sheet reflows to one column there, so group order is scroll distance, and the gestures were sitting below three groups of keyboard shortcuts.
- **Nothing names an input the device lacks.** The edit pill reads `drag atom = move · 2 fingers = orbit` on touch instead of RMB/Del/Esc; the sheet is titled "Shortcuts & gestures" rather than "Keyboard shortcuts" and drops its "? or Esc to close" hint on a coarse pointer.

## Verification

- 32 new tests. Whole suite **457 passing**, 32 suites, 0 failing; `npm run lint` and `tsc --noEmit` clean.
- Re-measured on the same 390×844 touch profile: main canvas `touch-action: none`, **every button ≥ 44×44**, one-finger drag rotates the camera, the sheet opens from the View menu with the touch group first and lists `pinch`, pill wording correct, no console errors.
- Desktop rendering and wording unchanged (checked at 1280 and 1600).

Two of the defects here came only from looking at the rendered result rather than the suite: the sheet still promised `?` and Escape on a device with neither and had no visible way out, and the touch group rendered last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185JNEgEJLfZZEx7jKHgwu5

---
_Generated by [Claude Code](https://claude.ai/code/session_0185JNEgEJLfZZEx7jKHgwu5)_